### PR TITLE
Update livro-de-regras.md

### DIFF
--- a/livro-de-regras.md
+++ b/livro-de-regras.md
@@ -183,7 +183,7 @@ Se houverem _Objeções_, elas devem ser integradas à proposta.
 
 #### Objeções
 
-Uma _Objeção_ é uma razão pela qual a proposta causa mal e move o _Círculo_ para trás. O _Facilitador_ pode fazer perguntas para ajudar o objetor a entender se as suas _Objeções_ são válidas ou não. Estas perguntas devem avaliar todos os quatro critérios a seguir:
+Uma _Objeção_ é uma razão pela qual a proposta causa mal e move o _Círculo_ para trás. O _Facilitador_ pode fazer perguntas para ajudar o objetor a entender se as suas _Objeções_ são válidas ou não. Uma objeção é considerada válida caso o objetor entenda que sua objeção atenda todos 4 critérios a seguir:
 
 1. **Degradação**. A _Objeção_ é sobre algum mal que a proposta poderia causar ao _Círculo_. Este dano deve ser explicado.
 2. **Causalidade**. Este mal é causado pela proposta, ou seja, ele não existiria sem ela. Só assim a _Objeção_ pode ser válida.


### PR DESCRIPTION
Modificado texto da seção "objeções" para dar mais clareza que é responsabilidade do objetor e não do facilitador (já que ele faz as perguntas) julgar se a objeção  passa necessariamente por todos  4 critérios.

**Texto Anterior:**
Uma _Objeção_ é uma razão pela qual a proposta causa mal e move o _Círculo_ para trás. O _Facilitador_ pode fazer perguntas para ajudar o objetor a entender se as suas _Objeções_ são válidas ou não. Estas perguntas devem avaliar todos os quatro critérios a seguir:

**Texto Sugerido;**
Uma _Objeção_ é uma razão pela qual a proposta causa mal e move o _Círculo_ para trás. O _Facilitador_ pode fazer perguntas para ajudar o objetor a entender se as suas _Objeções_ são válidas ou não. Uma objeção é considerada válida caso o objetor entenda que sua objeção atenda todos 4 critérios a seguir: