### PR TITLE
reunioes-de-circulo.md - Sobre convidados

### DIFF
--- a/meta-acordos/reunioes-de-circulo.md
+++ b/meta-acordos/reunioes-de-circulo.md
@@ -4,7 +4,7 @@
 
 ## Somente Membros podem processar tensões
 
-[Parceiros](organizacao.md#parceiros) que não são [Membros do Círculo](estrutura-organizacional.md#membros-do-circulo) não podem processar [Tensões](organizacao.md#tensoes) nas [Reuniões de Círculo](reunioes-de-circulo.md#reunioes-de-circulo), a não ser que sejam convidadas por um [Membro do Círculo](estrutura-organizacional.md#membros-do-circulo) para ajudar no processamento de uma [Tensão](organizacao.md#tensoes) específica.
+[Parceiros](organizacao.md#parceiros) que não são [Membros do Círculo](estrutura-organizacional.md#membros-do-circulo) não podem processar [Tensões](organizacao.md#tensoes) nas [Reuniões de Círculo](reunioes-de-circulo.md#reunioes-de-circulo). No entanto, [Parceiros](organizacao.md#parceiros) podem ser convidadas por um [Membro do Círculo](estrutura-organizacional.md#membros-do-circulo) para ajudar no processamento de uma [Tensão](organizacao.md#tensoes) específica. Neste caso, a tensão a ser processada ainda será considerada do [Membro do Círculo](estrutura-organizacional.md#membros-do-circulo) e não do [Parceiros](organizacao.md#parceiros).
 
 ## Formato da Reunião
 


### PR DESCRIPTION
Tensão: Em algumas reunioes de circulos que facilito, quando um parceiro era convidado para ajudar a processar uma tensão, alguns facilitadores e secretários entendiam que a tensão era do parceiro e não do membro do circulo que convidou. Acho que dando mais clareza de que a tensão sempre será do membro do circulo e nunca do parceiro naquela instância de reunião, essa diferença de entendimento talvez aconteça numa frequência menor. 