### PR TITLE
Elo Externo mais claro e adição de Meta-Acordo sobre energização

### DIFF
--- a/meta-acordos/direitos-e-deveres.md
+++ b/meta-acordos/direitos-e-deveres.md
@@ -16,11 +16,11 @@ Ao perseguir o [Propósito][papeis] dos seus [Papéis][papeis], os [Parceiros][p
 
 ## 3.4 <span id="direito-de-deixar-papeis">Direito de deixar Papéis</span>
 
-[Parceiros][parceiros] podem a qualquer momento deixar [Papéis][papeis] que desempenham em um ou mais [Círculos][circulos], a não ser que tenham de outra forma acordado com o [Elo Externo][elo-externo] ou outro processo que atribua [Parceiros][parceiros] a [Papéis][papeis].
+[Parceiros][parceiros] podem a qualquer momento deixar [Papéis][papeis] que energizam em um ou mais [Círculos][circulos], a não ser que tenham de outra forma acordado com o [Elo Externo][elo-externo] ou outro processo de [Energização][energizacao].
 
 ## 3.5 <span id="dever-da-expressao">Dever da expressão</span>
 
-Cada [Parceiro][parceiros] é responsável por identificar suas [Tensões][tensoes] a partir de cada [Papel][papeis] que desempenha. Cada [Parceiro][parceiros] também é responsável por tentar resolver essas [Tensões][tensoes], engajando outros [Parceiros][parceiros] em seus [Deveres][direitos-e-deveres] ou propondo mudanças na [Estrutura Organizacional][estrutura-organizacional].
+Cada [Parceiro][parceiros] é responsável por identificar suas [Tensões][tensoes] a partir de cada [Papel][papeis] que energiza. Cada [Parceiro][parceiros] também é responsável por tentar resolver essas [Tensões][tensoes], engajando outros [Parceiros][parceiros] em seus [Deveres][direitos-e-deveres] ou propondo mudanças na [Estrutura Organizacional][estrutura-organizacional].
 
 ## 3.6 <span id="dever-da-transparencia">Dever da transparência</span>
 
@@ -36,7 +36,7 @@ Quando solicitado, [Parceiros][parceiros] devem priorizar comparecer às [Reuni�
 
 ## 3.9 <span id="dever-da-preservacao">Dever da preservação</span>
 
-Os [Parceiros][parceiros], a partir dos seus [Papéis][papeis], não devem impactar os [Artefatos][papeis] de outros [Papéis][papeis] contidos no mesmo [Círculo][circulos], sem antes obter uma permissão explícita do [Parceiro][parceiros] que desempenha o [Papel][papeis] correspondente. Os [Parceiros][parceiros] também devem observar as [Restrições][restricoes] definidas na [Estrutura Organizacional][estrutura-organizacional] e seguir as condições nelas estabelecidas.
+Os [Parceiros][parceiros], a partir dos seus [Papéis][papeis], não devem impactar os [Artefatos][papeis] de outros [Papéis][papeis] contidos no mesmo [Círculo][circulos], sem antes obter uma permissão explícita do [Parceiro][parceiros] que energiza o [Papel][papeis] correspondente. Os [Parceiros][parceiros] também devem observar as [Restrições][restricoes] definidas na [Estrutura Organizacional][estrutura-organizacional] e seguir as condições nelas estabelecidas.
 
 <!-- Links -->
 [meta-acordos]: README.md
@@ -47,6 +47,7 @@ Os [Parceiros][parceiros], a partir dos seus [Papéis][papeis], não devem impac
 [direitos-e-deveres]: direitos-e-deveres.md
 [dever-da-preservacao]: direitos-e-deveres.md\#dever-da-preservacao
 [estrutura-organizacional]: estrutura-organizacional.md
+[energizacao]: estrutura-organizacional.md#energizacao
 [circulos]: estrutura-organizacional.md#circulos
 [papeis]: estrutura-organizacional.md#papeis
 [restricoes]: estrutura-organizacional.md#restricoes

--- a/meta-acordos/direitos-e-deveres.md
+++ b/meta-acordos/direitos-e-deveres.md
@@ -1,39 +1,54 @@
 # 3. <span id="direitos-e-deveres">Direitos e Deveres</span>
 
-Todos os [Parceiros](organizacao.md#parceiros) podem usufruir dos "Direitos" apresentados abaixo.
+Todos os [Parceiros][parceiros] podem usufruir dos "Direitos" apresentados abaixo.
 
 ## 3.1 <span id="direito-de-recusar-pedidos">Direito de recusar pedidos</span>
 
-[Parceiros](organizacao.md#parceiros) podem recusar pedidos, caso não exista uma [Responsabilidade](estrutura-organizacional.md#papeis) explícita correspondente na descrição do [Papel](estrutura-organizacional.md#papeis) sendo solicitado. Entretanto, os [Parceiros](organizacao.md#parceiros) devem sempre aceitar os pedidos que fizerem sentido para o [Propósito](estrutura-organizacional.md#papeis) de algum dos seus [Papéis](estrutura-organizacional.md#papeis), mesmo que nenhuma [Responsabilidade](estrutura-organizacional.md#papeis) explícita esteja registrada.
+[Parceiros][parceiros] podem recusar pedidos, caso não exista uma [Responsabilidade][papeis] explícita correspondente na descrição do [Papel][papeis] sendo solicitado. Entretanto, os [Parceiros][parceiros] devem sempre aceitar os pedidos que fizerem sentido para o [Propósito][papeis] de algum dos seus [Papéis][papeis], mesmo que nenhuma [Responsabilidade][papeis] explícita esteja registrada.
 
 ## 3.2 <span id="direito-de-agir-para-o-proposito">Direito de agir para o Propósito</span>
 
-Ao perseguir o [Propósito](estrutura-organizacional.md#papeis) dos seus [Papéis](estrutura-organizacional.md#papeis), os [Parceiros](organizacao.md#parceiros) estão sempre autorizados a tomar ação, a não ser que o [Dever da Preservação](direitos-e-deveres.md#dever-da-preservacao) os restrinja.
+Ao perseguir o [Propósito][papeis] dos seus [Papéis][papeis], os [Parceiros][parceiros] estão sempre autorizados a tomar ação, a não ser que o [Dever da Preservação][dever-da-preservacao] os restrinja.
 
 ## 3.3 <span id="direito-de-agir-heroicamente">Direito de agir heroicamente</span>
 
-[Parceiros](organizacao.md#parceiros) podem temporariamente ignorar estes Meta-Acordos se isto for útil e necessário para expressar o [Propósito Evolutivo](organizacao.md#proposito-evolutivo) da [Organização](organizacao.md). Iniciativas ou pedidos que possuem essa qualidade são chamados de "Atos Heróicos". Os [Parceiros](organizacao.md#parceiros) devem buscar reparar quaisquer danos causados após um Ato Heróico, propondo mudanças na [Estrutura Organizacional](estrutura-organizacional.md) ou até nestes [Meta-Acordos](direitos-e-deveres.md#meta-acordos) se necessário.
+[Parceiros][parceiros] podem temporariamente ignorar estes Meta-Acordos se isto for útil e necessário para expressar o [Propósito Evolutivo][proposito-evolutivo] da [Organização][organizacao]. Iniciativas ou pedidos que possuem essa qualidade são chamados de "Atos Heróicos". Os [Parceiros][parceiros] devem buscar reparar quaisquer danos causados após um Ato Heróico, propondo mudanças na [Estrutura Organizacional][estrutura-organizacional] ou até nestes [Meta-Acordos][meta-acordos] se necessário.
 
 ## 3.4 <span id="direito-de-deixar-papeis">Direito de deixar Papéis</span>
 
-[Parceiros](organizacao.md#parceiros) podem a qualquer momento deixar [Papéis](estrutura-organizacional.md#papeis) que desempenham em um ou mais [Círculos](estrutura-organizacional.md#circulos), a não ser que tenham de outra forma acordado com o [Elo Externo](papeis-essenciais.md#elo-externo) ou outro processo que atribua [Parceiros](organizacao.md#parceiros) a [Papéis](estrutura-organizacional.md#papeis).
+[Parceiros][parceiros] podem a qualquer momento deixar [Papéis][papeis] que desempenham em um ou mais [Círculos][circulos], a não ser que tenham de outra forma acordado com o [Elo Externo][elo-externo] ou outro processo que atribua [Parceiros][parceiros] a [Papéis][papeis].
 
 ## 3.5 <span id="dever-da-expressao">Dever da expressão</span>
 
-Cada [Parceiro](organizacao.md#parceiros) é responsável por identificar suas [Tensões](organizacao.md#tensoes) a partir de cada [Papel](estrutura-organizacional.md#papeis) que desempenha. Cada [Parceiro](organizacao.md#parceiros) também é responsável por tentar resolver essas [Tensões](organizacao.md#tensoes), engajando outros [Parceiros](organizacao.md#parceiros) em seus [Deveres](direitos-e-deveres.md#direitos-e-deveres) ou propondo mudanças na [Estrutura Organizacional](estrutura-organizacional.md).
+Cada [Parceiro][parceiros] é responsável por identificar suas [Tensões][tensoes] a partir de cada [Papel][papeis] que desempenha. Cada [Parceiro][parceiros] também é responsável por tentar resolver essas [Tensões][tensoes], engajando outros [Parceiros][parceiros] em seus [Deveres][direitos-e-deveres] ou propondo mudanças na [Estrutura Organizacional][estrutura-organizacional].
 
 ## 3.6 <span id="dever-da-transparencia">Dever da transparência</span>
 
-Quando solicitado, é esperado que os [Parceiros](organizacao.md#parceiros) compartilhem todas as informações relevantes sobre o trabalho de seus [Papéis](estrutura-organizacional.md#papeis), incluindo cada projeto que estão trabalhando, ações identificadas, critérios de priorização e métricas relevantes. Quando solicitado, também é esperado que os [Parceiros](organizacao.md#parceiros) dêem estimativas e projeções sobre possíveis datas de conclusão de seus trabalhos, mesmo que essas projeções não devam ser consideradas prazos ou compromissos.
+Quando solicitado, é esperado que os [Parceiros][parceiros] compartilhem todas as informações relevantes sobre o trabalho de seus [Papéis][papeis], incluindo cada projeto que estão trabalhando, ações identificadas, critérios de priorização e métricas relevantes. Quando solicitado, também é esperado que os [Parceiros][parceiros] dêem estimativas e projeções sobre possíveis datas de conclusão de seus trabalhos, mesmo que essas projeções não devam ser consideradas prazos ou compromissos.
 
 ## 3.7 <span id="dever-da-priorizacao">Dever da priorização</span>
 
-Os [Parceiros](organizacao.md#parceiros) devem priorizar o seu trabalho em alinhamento com as prioridades do [Círculo](estrutura-organizacional.md#circulos) definidas pelo [Elo Externo](papeis-essenciais.md#elo-externo) ou por qualquer outro processo que estabeleça prioridades para o [Círculo](estrutura-organizacional.md#circulos).
+Os [Parceiros][parceiros] devem priorizar o seu trabalho em alinhamento com as prioridades do [Círculo][circulos] definidas pelo [Elo Externo][elo-externo] ou por qualquer outro processo que estabeleça prioridades para o [Círculo][circulos].
 
 ## 3.8 <span id="dever-do-comparecimento">Dever do comparecimento</span>
 
-Quando solicitado, [Parceiros](organizacao.md#parceiros) devem priorizar comparecer às [Reuniões de Círculo](reunioes-de-circulo.md) em detrimento de trabalhar nos seus [Papéis](estrutura-organizacional.md#papeis).
+Quando solicitado, [Parceiros][parceiros] devem priorizar comparecer às [Reuniões de Círculo][reunioes-de-circulo] em detrimento de trabalhar nos seus [Papéis][papeis].
 
 ## 3.9 <span id="dever-da-preservacao">Dever da preservação</span>
 
-Os [Parceiros](organizacao.md#parceiros), a partir dos seus [Papéis](estrutura-organizacional.md#papeis), não devem impactar os [Artefatos](estrutura-organizacional.md#papeis) de outros [Papéis](estrutura-organizacional.md#papeis) contidos no mesmo [Círculo](estrutura-organizacional.md#circulos), sem antes obter uma permissão explícita do [Parceiro](organizacao.md#parceiros) que desempenha o [Papel](estrutura-organizacional.md#papeis) correspondente. Os [Parceiros](organizacao.md#parceiros) também devem observar as [Restrições](estrutura-organizacional.md#restricoes) definidas na [Estrutura Organizacional](estrutura-organizacional.md) e seguir as condições nelas estabelecidas.
+Os [Parceiros][parceiros], a partir dos seus [Papéis][papeis], não devem impactar os [Artefatos][papeis] de outros [Papéis][papeis] contidos no mesmo [Círculo][circulos], sem antes obter uma permissão explícita do [Parceiro][parceiros] que desempenha o [Papel][papeis] correspondente. Os [Parceiros][parceiros] também devem observar as [Restrições][restricoes] definidas na [Estrutura Organizacional][estrutura-organizacional] e seguir as condições nelas estabelecidas.
+
+<!-- Links -->
+[meta-acordos]: README.md
+[parceiros]: organizacao.md#parceiros
+[tensoes]: organizacao.md#tensoes
+[proposito-evolutivo]: organizacao.md#proposito-evolutivo
+[organizacao]: organizacao.md
+[direitos-e-deveres]: direitos-e-deveres.md
+[dever-da-preservacao]: direitos-e-deveres.md\#dever-da-preservacao
+[estrutura-organizacional]: estrutura-organizacional.md
+[circulos]: estrutura-organizacional.md#circulos
+[papeis]: estrutura-organizacional.md#papeis
+[restricoes]: estrutura-organizacional.md#restricoes
+[reunioes-de-circulo]: reunioes-de-circulo.md
+[elo-externo]: papeis-essenciais.md#elo-externo

--- a/meta-acordos/estrutura-organizacional.md
+++ b/meta-acordos/estrutura-organizacional.md
@@ -1,48 +1,65 @@
 # 2. <span id="estrutura-organizacional">Estrutura Organizacional</span>
 
-Os [Parceiros](organizacao.md#parceiros) poderão governar e definir uma camada de acordos que estabelece expectativas e limitações de autoridade entre eles. Esta camada, chamada de "Estrutura Organizacional", é organizada em uma hierarquia de [Círculos](estrutura-organizacional.md#circulos) e formada por [Papéis](estrutura-organizacional.md#papeis) e [Restrições](estrutura-organizacional.md#restricoes). Cada [Círculo](estrutura-organizacional.md#circulos) governa a sua Estrutura Organizacional, que somente pode ser alterada no [Modo Adaptar](https://github.com/targetteal/organic-organization/tree/69d2c84c987a1c8dba8ef1b3366c7c5863bf062f/meta-acordos/reunioes-de-circulo-md/README.md#modo-adaptar) da [Reunião de Círculo](https://github.com/targetteal/organic-organization/tree/69d2c84c987a1c8dba8ef1b3366c7c5863bf062f/meta-acordos/reunioes-de-circulo-md/README.md).
+Os [Parceiros][parceiros] poderão governar e definir uma camada de acordos que estabelece expectativas e limitações de autoridade entre eles. Esta camada, chamada de "Estrutura Organizacional", é organizada em uma hierarquia de [Círculos][circulos] e formada por [Papéis][papeis] e [Restrições][restricoes]. Cada [Círculo][circulos] governa a sua Estrutura Organizacional, que somente pode ser alterada no [Modo Adaptar][modo-adaptar].
 
 ## 2.1 <span id="papeis">Papéis</span>
 
-Os [Parceiros](organizacao.md#parceiros) executam o trabalho em um ou mais "Papéis" explicitamente definidos na [Estrutura Organizacional](estrutura-organizacional.md#estrutura-organizal). Um Papel é definido por:
+Os [Parceiros][parceiros] executam o trabalho em um ou mais "Papéis" explicitamente definidos na [Estrutura Organizacional][estrutura-organizacional]. Um Papel é definido por:
 
 * Um nome descritivo;
 * Um "Propósito", que é uma capacidade, potencial ou objetivo inalcançável que o Papel irá perseguir ou expressar;
-* Zero ou mais "Responsabilidades", que são atividades contínuas que outros [Parceiros](organizacao.md#parceiros) podem esperar que o Papel irá executar;
-* Zero ou mais "Artefatos", que são ativos que o Papel pode exclusivamente controlar e regular em nome da [Organização](organizacao.md).
+* Zero ou mais "Responsabilidades", que são atividades contínuas que outros [Parceiros][parceiros] podem esperar que o Papel irá executar;
+* Zero ou mais "Artefatos", que são ativos que o Papel pode exclusivamente controlar e regular em nome da [Organização][organizacao].
 
 ## 2.2 <span id="circulos">Círculos</span>
 
-Um "Círculo" é um [Papel](estrutura-organizacional.md#papeis) que possui a autoridade de se dividir em [Papéis](estrutura-organizacional.md#papeis) menores, contidos dentro dele mesmo. Quando um [Papel](estrutura-organizacional.md#papeis) é transformado em um Círculo, os [Parceiros](organizacao.md#parceiros) que o desempenhavam tornam-se o [Elo Externo](papeis-essenciais.md#elo-externo) daquele [Círculo](estrutura-organizacional.md#circulos). [Círculos](estrutura-organizacional.md#circulos) são definidos exatamente como os [Papéis](estrutura-organizacional.md#papeis), ou seja, através dos elementos nome, [Propósito](estrutura-organizacional.md#papeis), [Responsabilidades](estrutura-organizacional.md#papeis) e [Artefatos](estrutura-organizacional.md#papeis).
+Um "Círculo" é um [Papel][papeis] que possui a autoridade de se dividir em [Papéis][papeis] menores, contidos dentro dele mesmo. Quando um [Papel][papeis] é transformado em um Círculo, os [Parceiros][parceiros] que o desempenhavam tornam-se o [Elo Externo][elo-externo] daquele [Círculo][circulos]. [Círculos][circulos] são definidos exatamente como os [Papéis][papeis], ou seja, através dos elementos nome, [Propósito][papeis], [Responsabilidades][papeis] e [Artefatos][papeis].
 
 ### 2.2.1 <span id="circulos-nao-alteram-sua-definicao">Círculos não alteram sua definição</span>
 
-Um [Círculo](estrutura-organizacional.md#circulos) pode governar os seus próprios [Papéis](estrutura-organizacional.md#papeis) e [Restrições](estrutura-organizacional.md#restricoes), mas não pode alterar a sua própria definição, pois isto deve ser feito no [Círculo](estrutura-organizacional.md#circulos) externo que contém este [Círculo](estrutura-organizacional.md#circulos).
+Um [Círculo][circulos] pode governar os seus próprios [Papéis][papeis] e [Restrições][restricoes], mas não pode alterar a sua própria definição, pois isto deve ser feito no [Círculo][circulos] externo que contém este [Círculo][circulos].
 
 ### 2.2.2 <span id="circulos-nao-estruturam-seus-circulos-internos">Círculos não estruturam seus Círculos internos</span>
 
-Um [Círculo](estrutura-organizacional.md#circulos) não pode alterar os [Papéis](estrutura-organizacional.md#papeis), [Círculos](estrutura-organizacional.md#circulos) e [Restrições](estrutura-organizacional.md#restricoes) de um [Círculo](estrutura-organizacional.md#circulos) interno diretamente. No entanto, um [Círculo](estrutura-organizacional.md#circulos) pode realizar algumas operações no [Modo Adaptar](https://github.com/targetteal/organic-organization/tree/69d2c84c987a1c8dba8ef1b3366c7c5863bf062f/meta-acordos/reunioes-de-circulo-md/README.md#modo-adaptar), como mover [Papéis](estrutura-organizacional.md#papeis) de si para os seus [Círculos](estrutura-organizacional.md#circulos) internos e vice-versa.
+Um [Círculo][circulos] não pode alterar os [Papéis][papeis], [Círculos][circulos] e [Restrições][restricoes] de um [Círculo][circulos] interno diretamente. No entanto, um [Círculo][circulos] pode realizar algumas operações no [Modo Adaptar][modo-adaptar], como mover [Papéis][papeis] de si para os seus [Círculos][circulos] internos e vice-versa.
 
 ## 2.3 <span id="artefatos-do-circulo">Artefatos do Círculo</span>
 
-Quando um [Círculo](estrutura-organizacional.md#circulos) possui [Artefatos](estrutura-organizacional.md#papeis) na sua definição, somente [Membros do Círculo](estrutura-organizacional.md#membros-do-circulo) podem impactar estes [Artefatos](estrutura-organizacional.md#papeis) sem violar o [Dever da preservação](direitos-e-deveres.md#dever-da-preservacao).
+Quando um [Círculo][circulos] possui [Artefatos][papeis] na sua definição, somente [Membros do Círculo][membros-do-circulo] podem impactar estes [Artefatos][papeis] sem violar o [Dever da preservação][dever-da-preservacao].
 
 ### 2.3.1 <span id="circulos-podem-delegar-artefatos">Círculos podem delegar Artefatos</span>
 
-Através do seu [Modo Adaptar](https://github.com/targetteal/organic-organization/tree/69d2c84c987a1c8dba8ef1b3366c7c5863bf062f/meta-acordos/reunioes-de-circulo-md/README.md#modo-adaptar), um [Círculo](estrutura-organizacional.md#circulos) pode especificar um de seus [Artefatos](estrutura-organizacional.md#papeis) em um [Papel](estrutura-organizacional.md#papeis) ou [Círculo](estrutura-organizacional.md#circulos) interno. Se isto for feito, aquele [Artefato](estrutura-organizacional.md#papeis) passa a ser exclusivo do [Papel](estrutura-organizacional.md#papeis) ou [Círculo](estrutura-organizacional.md#circulos) interno.
+Através do seu [Modo Adaptar][modo-adaptar], um [Círculo][circulos] pode especificar um de seus [Artefatos][papeis] em um [Papel][papeis] ou [Círculo][circulos] interno. Se isto for feito, aquele [Artefato][papeis] passa a ser exclusivo do [Papel][papeis] ou [Círculo][circulos] interno.
 
 ## 2.4 <span id="membros-do-circulo">Membros do Círculo</span>
 
-[Parceiros](organizacao.md#parceiros) são considerados "Membros" de um determinado [Círculo](estrutura-organizacional.md#circulos) quando atenderem pelo menos um dos critérios abaixo:
+[Parceiros][parceiros] são considerados "Membros" de um determinado [Círculo][circulos] quando atenderem pelo menos um dos critérios abaixo:
 
-* Desempenham pelo menos um [Papel](estrutura-organizacional.md#papeis) definido no [Círculo](estrutura-organizacional.md#circulos);
-* Desempenham pelo menos um dos [Papéis Essenciais](papeis-essenciais.md) no [Círculo](estrutura-organizacional.md#circulos);
-* Desempenham o [Papel](estrutura-organizacional.md#papeis) de [Elo Externo](papeis-essenciais.md#elo-externo) ou [Elo Interno](papeis-essenciais.md#elo-interno) em pelo menos um dos [Círculos](estrutura-organizacional.md#circulos) internos ao [Círculo](estrutura-organizacional.md#circulos).
+* Desempenham pelo menos um [Papel][papeis] definido no [Círculo][circulos];
+* Desempenham pelo menos um dos [Papéis Essenciais][papeis-essenciais] no [Círculo][circulos];
+* Desempenham o [Papel][papeis] de [Elo Externo][elo-externo] ou [Elo Interno][elo-interno] em pelo menos um dos [Círculos][circulos] internos ao [Círculo][circulos].
 
 ## 2.5 <span id="restricoes">Restrições</span>
 
-"Restrições" são limitações de autoridade que aplicam-se a todos os [Papéis](estrutura-organizacional.md#papeis) de um [Círculo](estrutura-organizacional.md#circulos). Restrições são compostas por um nome e uma descrição. A não ser que de outra forma especificado em sua descrição, o efeito de uma Restrição se aplica a todos os [Papéis](estrutura-organizacional.md#papeis) e [Círculos](estrutura-organizacional.md#circulos) internos ao [Círculo](estrutura-organizacional.md#circulos) onde ela é definida. Uma Restrição é parte de um [Círculo](estrutura-organizacional.md#circulos), assim como um [Papel](estrutura-organizacional.md#papeis) ou [Círculo](estrutura-organizacional.md#circulos) interno.
+"Restrições" são limitações de autoridade que aplicam-se a todos os [Papéis][papeis] de um [Círculo][circulos]. Restrições são compostas por um nome e uma descrição. A não ser que de outra forma especificado em sua descrição, o efeito de uma Restrição se aplica a todos os [Papéis][papeis] e [Círculos][circulos] internos ao [Círculo][circulos] onde ela é definida. Uma Restrição é parte de um [Círculo][circulos], assim como um [Papel][papeis] ou [Círculo][circulos] interno.
 
 ### 2.5.1 <span id="restricoes-nao-estabelecem-expectativas">Restrições não estabelecem expectativas</span>
 
-[Restrições](estrutura-organizacional.md#restricoes) não podem estabelecer expectativas, porque este é o objetivo de uma [Responsabilidade](estrutura-organizacional.md#papeis). Ainda assim, uma [Restrição](estrutura-organizacional.md#restricoes) pode exigir ação, mas apenas para [Parceiros](organizacao.md#parceiros) em que a [Restrição](estrutura-organizacional.md#restricoes) se aplica na condição específica que desencadeia ela.
+[Restrições][restricoes] não podem estabelecer expectativas, porque este é o objetivo de uma [Responsabilidade][papeis]. Ainda assim, uma [Restrição][restricoes] pode exigir ação, mas apenas para [Parceiros][parceiros] em que a [Restrição][restricoes] se aplica na condição específica que desencadeia ela.
+
+<!-- Links -->
+[organizacao]: organizacao.md
+[parceiros]: organizacao.md#parceiros
+[tensoes]: organizacao.md#tensoes
+[proposito-evolutivo]: organizacao.md#proposito-evolutivo
+[organizacao]: organizacao.md
+[dever-da-preservacao]: direitos-e-deveres.md#dever-da-preservacao
+[estrutura-organizacional]: estrutura-organizacional.md
+[circulos]: estrutura-organizacional.md#circulos
+[membros-do-circulo]: estrutura-organizacional.md#membros-do-circulo
+[papeis]: estrutura-organizacional.md#papeis
+[restricoes]: estrutura-organizacional.md#restricoes
+[modo-adaptar]: reunioes-de-circulo.md#modo-adaptar
+[papeis-essenciais]: papeis-essenciais.md
+[elo-externo]: papeis-essenciais.md#elo-externo
+[elo-interno]: papeis-essenciais.md#elo-interno

--- a/meta-acordos/estrutura-organizacional.md
+++ b/meta-acordos/estrutura-organizacional.md
@@ -11,9 +11,13 @@ Os [Parceiros][parceiros] executam o trabalho em um ou mais "Papéis" explicitam
 * Zero ou mais "Responsabilidades", que são atividades contínuas que outros [Parceiros][parceiros] podem esperar que o Papel irá executar;
 * Zero ou mais "Artefatos", que são ativos que o Papel pode exclusivamente controlar e regular em nome da [Organização][organizacao].
 
+## 2.1.1 <span id="energizacao">Energização</span>
+
+A "Energização" diz respeito a quais [Parceiros][parceiros] dedicam seu tempo e energia à expressão do [Propósito][papeis] de quais [Papéis][papeis]. A Energização não é um componente da [Estrutura Organizacional][estrutura-organizacional], embora esta possa determinar como e em que condições ela ocorre.
+
 ## 2.2 <span id="circulos">Círculos</span>
 
-Um "Círculo" é um [Papel][papeis] que possui a autoridade de se dividir em [Papéis][papeis] menores, contidos dentro dele mesmo. Quando um [Papel][papeis] é transformado em um Círculo, os [Parceiros][parceiros] que o desempenhavam tornam-se o [Elo Externo][elo-externo] daquele [Círculo][circulos]. [Círculos][circulos] são definidos exatamente como os [Papéis][papeis], ou seja, através dos elementos nome, [Propósito][papeis], [Responsabilidades][papeis] e [Artefatos][papeis].
+Um "Círculo" é um [Papel][papeis] que possui a autoridade de se dividir em [Papéis][papeis] menores, contidos dentro dele mesmo. Quando um [Papel][papeis] é transformado em um Círculo, os [Parceiros][parceiros] que o energizam tornam-se o [Elo Externo][elo-externo] daquele [Círculo][circulos]. [Círculos][circulos] são definidos exatamente como os [Papéis][papeis], ou seja, através dos elementos nome, [Propósito][papeis], [Responsabilidades][papeis] e [Artefatos][papeis].
 
 ### 2.2.1 <span id="circulos-nao-alteram-sua-definicao">Círculos não alteram sua definição</span>
 
@@ -35,9 +39,9 @@ Através do seu [Modo Adaptar][modo-adaptar], um [Círculo][circulos] pode espec
 
 [Parceiros][parceiros] são considerados "Membros" de um determinado [Círculo][circulos] quando atenderem pelo menos um dos critérios abaixo:
 
-* Desempenham pelo menos um [Papel][papeis] definido no [Círculo][circulos];
-* Desempenham pelo menos um dos [Papéis Essenciais][papeis-essenciais] no [Círculo][circulos];
-* Desempenham o [Papel][papeis] de [Elo Externo][elo-externo] ou [Elo Interno][elo-interno] em pelo menos um dos [Círculos][circulos] internos ao [Círculo][circulos].
+* Energizam pelo menos um [Papel][papeis] definido no [Círculo][circulos];
+* Energizam pelo menos um dos [Papéis Essenciais][papeis-essenciais] no [Círculo][circulos];
+* Energizam o [Papel][papeis] de [Elo Externo][elo-externo] ou [Elo Interno][elo-interno] em pelo menos um dos [Círculos][circulos] internos ao [Círculo][circulos].
 
 ## 2.5 <span id="restricoes">Restrições</span>
 

--- a/meta-acordos/organizacao.md
+++ b/meta-acordos/organizacao.md
@@ -1,15 +1,23 @@
 # 1. <span id="organizacao">Organização</span>
 
-A "Organização" é uma entidade criada para expressar um [Propósito Evolutivo](organizacao.md#proposito-evolutivo). Uma Organização possui ativos que controla e uma fronteira clara com o mundo exterior.
+A "Organização" é uma entidade criada para expressar um [Propósito Evolutivo][proposito-evolutivo]. Uma Organização possui ativos que controla e uma fronteira clara com o mundo exterior.
 
 ## 1.1 <span id="proposito-evolutivo">Propósito Evolutivo</span>
 
-A [Organização](organizacao.md#organizacao) possui um "Propósito Evolutivo", que corresponde ao _potencial criativo mais profundo que pode expressar de forma sustentável no mundo_. O Propósito Evolutivo é o [Propósito](estrutura-organizacional.md#papeis) do [Círculo](estrutura-organizacional.md#circulos) mais amplo da [Estrutura Organizacional](estrutura-organizacional.md).
+A [Organização][organizacao] possui um "Propósito Evolutivo", que corresponde ao _potencial criativo mais profundo que pode expressar de forma sustentável no mundo_. O Propósito Evolutivo é o [Propósito][papeis] do [Círculo][circulos] mais amplo da [Estrutura Organizacional][estrutura-organizacional].
 
 ## 1.2 <span id="parceiros">Parceiros</span>
 
-A [Organização](organizacao.md#organizacao) pode ter um ou mais "Parceiros", que são pessoas que energizam [Papéis](estrutura-organizacional.md#papeis) e expressam o [Propósito Evolutivo](organizacao.md#proposito-evolutivo).
+A [Organização][organizacao] pode ter um ou mais "Parceiros", que são pessoas que energizam [Papéis][papeis] e expressam o [Propósito Evolutivo][proposito-evolutivo].
 
 ## 1.3 <span id="tensoes">Tensões</span>
 
-Ao perseguir o [Propósito](estrutura-organizacional.md#papeis) de um ou mais [Papeis](estrutura-organizacional.md#papeis), os [Parceiros](organizacao.md#parceiros) podem identificar uma diferença entre a realidade atual e um potencial que percebem. Estas lacunas, que podem ser problemas ou oportunidades identificadas, são denominadas "Tensões Criativas", ou simplesmente "Tensões" . As Tensões movimentam a [Organização](organizacao.md#organizacao) em direção ao seu [Propósito Evolutivo](organizacao.md#proposito-evolutivo).
+Ao perseguir o [Propósito][papeis] de um ou mais [Papeis][papeis], os [Parceiros][parceiros] podem identificar uma diferença entre a realidade atual e um potencial que percebem. Estas lacunas, que podem ser problemas ou oportunidades identificadas, são denominadas "Tensões Criativas", ou simplesmente "Tensões" . As Tensões movimentam a [Organização][organizacao] em direção ao seu [Propósito Evolutivo][proposito-evolutivo].
+
+<!-- Links -->
+[organizacao]: #organizacao
+[parceiros]: #parceiros
+[proposito-evolutivo]: #proposito-evolutivo
+[papeis]: estrutura-organizacional.md#papeis
+[circulos]: estrutura-organizacional.md#circulos
+[estrutura-organizacional]: estrutura-organizacional.md

--- a/meta-acordos/papeis-essenciais.md
+++ b/meta-acordos/papeis-essenciais.md
@@ -24,9 +24,9 @@ As alterações realizadas nos [Papeis Essenciais][papeis-essenciais] de um [Cí
 
 O [Elo Externo][elo-externo] é escolhido pelo [Círculo][circulos] externo, por qualquer processo que atribua [Parceiros][parceiros] a [Papéis][papeis] no [Círculo][circulos] externo. O [Elo Externo][elo-externo] do [Círculo][circulos] mais amplo deve ser determinado pelo mesmo processo que adotou estes Meta-Acordos.
 
-## 5.4 <span id="atribuicao-de-parceiros-a-papeis">Atribuição de Parceiros a Papéis</span>
+## 5.4 <span id="atribuicao-de-parceiros-a-papeis">Energização de Papéis</span>
 
-O [Elo Externo][elo-externo] é responsável por atribuir [Parceiros][parceiros] aos [Papéis][papeis] no [Círculo][circulos] e pode convidar qualquer [Parceiro][parceiros] da [Organização][organizacao], a não ser que uma [Restrição][restricoes] diga o contrário.
+O [Elo Externo][elo-externo] é responsável por convidar [Parceiros][parceiros] para energizarem os [Papéis][papeis] definidos no [Círculo][circulos] e pode convidar qualquer [Parceiro][parceiros] da [Organização](organizacao.md), a não ser que uma [Restrição][restricoes] diga o contrário.
 
 ## 5.5 <span id="facilitador">Facilitador</span>
 
@@ -63,12 +63,13 @@ O [Papel][papeis] do "Elo Externo" possui a seguinte definição inicial:
 **Responsabilidades**:
 
 * Estruturar o [Círculo][circulos] para expressar o seu [Propósito][papeis]
-* Atribuir [Parceiros][parceiros] aos [Papéis][papeis] do [Círculo][circulos]; monitorar a adequação; oferecer feedback para melhorar a adequação; e re-atribuir [Papéis][papeis] a outros [Parceiros][parceiros], quando necessário
+* Convidar [Parceiros][parceiros] para energizarem [Papéis][papeis] do [Círculo][circulos]
+* Oferecer feedback para melhorar a adequação entre [Parceiro][parceiros] e [Papel][papeis], desenergizando quando necessário
 * Estabelecer prioridades para o [Círculo][circulos]
 
 **Artefatos**:
 
-* Atribuição de [Papéis][papeis] dentro do [Círculo][circulos]
+* Energização de [Papéis][papeis] dentro do [Círculo][circulos]
 
 O Elo Externo detém todas as [Responsabilidades][papeis] e [Artefatos][papeis] não delegados do [Círculo][circulos].
 

--- a/meta-acordos/papeis-essenciais.md
+++ b/meta-acordos/papeis-essenciais.md
@@ -1,84 +1,101 @@
 # 5. <span id="papeis-essenciais">Papéis Essenciais</span>
 
-Cada [Círculo](estrutura-organizacional.md#circulos) contém 4 "Papéis Essenciais" automaticamente criados: [Elo Externo](papeis-essenciais.md#elo-externo), [Elo Interno](papeis-essenciais.md#elo-interno), [Facilitador](papeis-essenciais.md#facilitador) e [Secretário](papeis-essenciais.md#secretario).
+Cada [Círculo][circulos] contém 4 "Papéis Essenciais" automaticamente criados: [Elo Externo][elo-externo], [Elo Interno][elo-interno], [Facilitador][facilitador] e [Secretário][secretario].
 
 ## 5.1 <span id="papeis-essenciais-eleitos">Papéis Essenciais Eleitos</span>
 
-Quando um [Círculo](estrutura-organizacional.md#circulos) possui dois ou mais [Parceiros](organizacao.md#parceiros), ele deve eleger no [Modo Selecionar](reunioes-de-circulo.md#modo-selecionar) os 3 "Papéis Essenciais Eleitos" de [Facilitador](papeis-essenciais.md#facilitador), [Secretário](papeis-essenciais.md#secretario) e [Elo Interno](papeis-essenciais.md#elo-interno). A única exceção é o [Círculo](estrutura-organizacional.md#circulos) mais amplo da [Estrutura Organizacional](estrutura-organizacional.md), que não deve eleger [Elo Interno](papeis-essenciais.md#elo-interno).
+Quando um [Círculo][circulos] possui dois ou mais [Parceiros][parceiros], ele deve eleger no [Modo Selecionar][modo-selecionar] os 3 "Papéis Essenciais Eleitos" de [Facilitador][facilitador], [Secretário][secretario] e [Elo Interno][elo-interno]. A única exceção é o [Círculo][circulos] mais amplo da [Estrutura Organizacional][estrutura-organizacional], que não deve eleger [Elo Interno][elo-interno].
 
 ## 5.2 <span id="alteracoes-nos-papeis-essenciais">Alterações nos Papéis Essenciais</span>
 
-Os [Papéis Essenciais](papeis-essenciais.md#papeis-essenciais) de cada [Círculo](estrutura-organizacional.md#circulos) podem ser alterados durante o [Modo Adaptar](reunioes-de-circulo.md#modo-adaptar). No entanto, as seguintes restrições se aplicam:
+Os [Papéis Essenciais][papeis-essenciais] de cada [Círculo][circulos] podem ser alterados durante o [Modo Adaptar][modo-adaptar]. No entanto, as seguintes restrições se aplicam:
 
-* O nome e o [Propósito](estrutura-organizacional.md#papeis) dos [Papéis Essenciais](papeis-essenciais.md#papeis-essenciais) não pode ser alterado;
-* Novas [Responsabilidades](estrutura-organizacional.md#papeis) e [Artefatos](estrutura-organizacional.md#papeis) não podem ser acrescidas ao [Papel](estrutura-organizacional.md#papeis) do [Elo Externo](papeis-essenciais.md#elo-externo);
-* As [Responsabilidades](estrutura-organizacional.md#papeis) e [Artefatos](estrutura-organizacional.md#papeis) iniciais do Papel [Elo Externo](papeis-essenciais.md#elo-externo) podem ser modificadas ou removidas completamente, desde que sejam delegadas a outro [Papel](estrutura-organizacional.md#papeis) ou processo no [Círculo](estrutura-organizacional.md#circulos);
-* As [Responsabilidades](estrutura-organizacional.md#papeis) e [Artefatos](estrutura-organizacional.md#papeis) iniciais dos [Papéis](estrutura-organizacional.md#papeis) de [Facilitador](papeis-essenciais.md#facilitador), [Secretário](papeis-essenciais.md#secretario) e [Elo Interno](papeis-essenciais.md#elo-interno) não podem ser removidas ou modificadas;
-* Os [Papéis Essenciais](papeis-essenciais.md#papeis-essenciais) não podem ser removidos.
+* O nome e o [Propósito][papeis] dos [Papéis Essenciais][papeis-essenciais] não pode ser alterado;
+* Novas [Responsabilidades][papeis] e [Artefatos][papeis] não podem ser acrescidas ao [Papel][papeis] do [Elo Externo][elo-externo];
+* As [Responsabilidades][papeis] e [Artefatos][papeis] iniciais do Papel [Elo Externo][elo-externo] podem ser modificadas ou removidas completamente, desde que sejam delegadas a outro [Papel][papeis] ou processo no [Círculo][circulos];
+* As [Responsabilidades][papeis] e [Artefatos][papeis] iniciais dos [Papéis][papeis] de [Facilitador][facilitador], [Secretário][secretario] e [Elo Interno][elo-interno] não podem ser removidas ou modificadas;
+* Os [Papéis Essenciais][papeis-essenciais] não podem ser removidos.
 
 ### 5.2.1 <span id="alteracoes-nos-papeis-essenciais-nao-propagam">Alterações nos Papéis Essenciais não propagam</span>
 
-As alterações realizadas nos [Papeis Essenciais](papeis-essenciais.md#papeis-essenciais) de um [Círculo](estrutura-organizacional.md#circulos) aplicam-se apenas ao [Círculo](estrutura-organizacional.md#circulos) onde a modificação ocorreu, ou seja, não propagam para os [Círculos](estrutura-organizacional.md#circulos) internos.
+As alterações realizadas nos [Papeis Essenciais][papeis-essenciais] de um [Círculo][circulos] aplicam-se apenas ao [Círculo][circulos] onde a modificação ocorreu, ou seja, não propagam para os [Círculos][circulos] internos.
 
 ## 5.3 <span id="escolha-do-elo-externo">Escolha do Elo Externo</span>
 
-O [Elo Externo](papeis-essenciais.md#elo-externo) é escolhido pelo [Círculo](estrutura-organizacional.md#circulos) externo, por qualquer processo que atribua [Parceiros](organizacao.md#parceiros) a [Papéis](estrutura-organizacional.md#papeis) no [Círculo](estrutura-organizacional.md#circulos) externo. O [Elo Externo](papeis-essenciais.md#elo-externo) do [Círculo](estrutura-organizacional.md#circulos) mais amplo deve ser determinado pelo mesmo processo que adotou estes Meta-Acordos.
+O [Elo Externo][elo-externo] é escolhido pelo [Círculo][circulos] externo, por qualquer processo que atribua [Parceiros][parceiros] a [Papéis][papeis] no [Círculo][circulos] externo. O [Elo Externo][elo-externo] do [Círculo][circulos] mais amplo deve ser determinado pelo mesmo processo que adotou estes Meta-Acordos.
 
 ## 5.4 <span id="atribuicao-de-parceiros-a-papeis">Atribuição de Parceiros a Papéis</span>
 
-O [Elo Externo](papeis-essenciais.md#elo-externo) é responsável por atribuir [Parceiros](organizacao.md#parceiros) aos [Papéis](estrutura-organizacional.md#papeis) no [Círculo](estrutura-organizacional.md#circulos) e pode convidar qualquer [Parceiro](organizacao.md#parceiros) da [Organização](organizacao.md), a não ser que uma [Restrição](estrutura-organizacional.md#restricoes) diga o contrário.
+O [Elo Externo][elo-externo] é responsável por atribuir [Parceiros][parceiros] aos [Papéis][papeis] no [Círculo][circulos] e pode convidar qualquer [Parceiro][parceiros] da [Organização][organizacao], a não ser que uma [Restrição][restricoes] diga o contrário.
 
 ## 5.5 <span id="facilitador">Facilitador</span>
 
-O [Papel](estrutura-organizacional.md#papeis) do "Facilitador" possui a seguinte definição inicial:
+O [Papel][papeis] do "Facilitador" possui a seguinte definição inicial:
 
-**Propósito**: [_Reuniões de Círculo_](reunioes-de-circulo.md) _saudáveis e alinhadas com os Meta-Acordos_
+**Propósito**: [_Reuniões de Círculo_][reunioes-de-circulo] _saudáveis e alinhadas com os Meta-Acordos_
 
 **Responsabilidades**:
 
-* Facilitar as [Reuniões de Círculo](reunioes-de-circulo.md)
+* Facilitar as [Reuniões de Círculo][reunioes-de-circulo]
 
 ## 5.6 <span id="secretario">Secretário</span>
 
-O [Papel](estrutura-organizacional.md#papeis) do "Secretário" possui a seguinte definição inicial:
+O [Papel][papeis] do "Secretário" possui a seguinte definição inicial:
 
-**Propósito**: _Meta-Acordos e_ [_Estrutura Organizacional_](estrutura-organizacional.md) _do_ [_Círculo_](estrutura-organizacional.md#circulos) _claros_
+**Propósito**: _Meta-Acordos e_ [_Estrutura Organizacional_][estrutura-organizacional] _do_ [_Círculo_][circulos] _claros_
 
 **Responsabilidades**:
 
-* Agendar [Reuniões de Círculo](reunioes-de-circulo.md) regulares
-* Registar as saídas das [Reuniões de Círculo](reunioes-de-circulo.md)
-* Interpretar os Meta-Acordos e a [Estrutura Organizacional](estrutura-organizacional.md) mediante solicitações
+* Agendar [Reuniões de Círculo][reunioes-de-circulo] regulares
+* Registar as saídas das [Reuniões de Círculo][reunioes-de-circulo]
+* Interpretar os Meta-Acordos e a [Estrutura Organizacional][estrutura-organizacional] mediante solicitações
 
 **Artefatos**:
 
-* Registros da [Estrutura Organizacional](estrutura-organizacional.md) do [Círculo](estrutura-organizacional.md#circulos)
+* Registros da [Estrutura Organizacional][estrutura-organizacional] do [Círculo][circulos]
 
 ## 5.7 <span id="elo-externo">Elo Externo</span>
 
-O [Papel](estrutura-organizacional.md#papeis) do "Elo Externo" possui a seguinte definição inicial:
+O [Papel][papeis] do "Elo Externo" possui a seguinte definição inicial:
 
-**Propósito**: _O_ [_Propósito_](estrutura-organizacional.md#papeis) _do_ [_Círculo_](estrutura-organizacional.md#circulos)
+**Propósito**: _O_ [_Propósito_][papeis] _do_ [_Círculo_][circulos]
 
 **Responsabilidades**:
 
-* Estruturar o [Círculo](estrutura-organizacional.md#circulos) para expressar o seu [Propósito](estrutura-organizacional.md#papeis)
-* Atribuir [Parceiros](organizacao.md#parceiros) aos [Papéis](estrutura-organizacional.md#papeis) do [Círculo](estrutura-organizacional.md#circulos); monitorar a adequação; oferecer feedback para melhorar a adequação; e re-atribuir [Papéis](estrutura-organizacional.md#papeis) a outros [Parceiros](organizacao.md#parceiros), quando necessário
-* Estabelecer prioridades para o [Círculo](estrutura-organizacional.md#circulos)
+* Estruturar o [Círculo][circulos] para expressar o seu [Propósito][papeis]
+* Atribuir [Parceiros][parceiros] aos [Papéis][papeis] do [Círculo][circulos]; monitorar a adequação; oferecer feedback para melhorar a adequação; e re-atribuir [Papéis][papeis] a outros [Parceiros][parceiros], quando necessário
+* Estabelecer prioridades para o [Círculo][circulos]
 
 **Artefatos**:
 
-* Atribuição de [Papéis](estrutura-organizacional.md#papeis) dentro do [Círculo](estrutura-organizacional.md#circulos)
+* Atribuição de [Papéis][papeis] dentro do [Círculo][circulos]
 
-O Elo Externo detém todas as [Responsabilidades](estrutura-organizacional.md#papeis) e [Artefatos](estrutura-organizacional.md#papeis) não delegados do [Círculo](estrutura-organizacional.md#circulos).
+O Elo Externo detém todas as [Responsabilidades][papeis] e [Artefatos][papeis] não delegados do [Círculo][circulos].
 
 ## 5.8 <span id="elo-interno">Elo Interno</span>
 
-O [Papel](estrutura-organizacional.md#papeis) do "Elo Interno" possui a seguinte definição inicial:
+O [Papel][papeis] do "Elo Interno" possui a seguinte definição inicial:
 
-**Propósito**: _O_ [_Propósito_](estrutura-organizacional.md#papeis) _do_ [_Círculo_](estrutura-organizacional.md#circulos)
+**Propósito**: _O_ [_Propósito_][papeis] _do_ [_Círculo_][circulos]
 
 **Responsabilidades**:
 
-* Buscar compreender [Tensões](organizacao.md#tensoes) trazidas pelos [Membros do Círculo](estrutura-organizacional.md#membros-do-circulo), e processá-las quando apropriado no [Círculo](estrutura-organizacional.md#circulos) externo
-* Fornecer visibilidade sobre a saúde do [Círculo](estrutura-organizacional.md#circulos) para o [Círculo](estrutura-organizacional.md#circulos) externo
+* Buscar compreender [Tensões][tensoes] trazidas pelos [Membros do Círculo][membros-do-circulo], e processá-las quando apropriado no [Círculo][circulos] externo
+* Fornecer visibilidade sobre a saúde do [Círculo][circulos] para o [Círculo][circulos] externo
+
+<!-- Links -->
+[organizacao]: organizacao.md
+[parceiros]: organizacao.md#parceiros
+[tensoes]: organizacao.md#tensoes
+[estrutura-organizacional]: estrutura-organizacional.md
+[circulos]: estrutura-organizacional.md#circulos
+[membros-do-circulo]: estrutura-organizacional.md#membros-do-circulo
+[papeis]: estrutura-organizacional.md#papeis
+[restricoes]: estrutura-organizacional.md#restricoes
+[reunioes-de-circulo]: reunioes-de-circulo.md
+[modo-selecionar]: reunioes-de-circulo.md#modo-selecionar
+[papeis-essenciais]: papeis-essenciais.md
+[elo-externo]: papeis-essenciais.md#elo-externo
+[elo-interno]: papeis-essenciais.md#elo-interno
+[facilitador]: papeis-essenciais.md#facilitador
+[secretario]: papeis-essenciais.md#secretario

--- a/meta-acordos/reunioes-de-circulo.md
+++ b/meta-acordos/reunioes-de-circulo.md
@@ -84,7 +84,7 @@ Alterações na [Estrutura Organizacional][estrutura-organizacional] do [Círcul
 
 ## 4.7 <span id="modo-selecionar">Modo Selecionar</span>
 
-O "Modo Selecionar" é um momento da [Reunião de Círculo][reunioes-de-circulo] cujo objetivo é _escolher_ [_Membros do Círculo_][membros-do-circulo] _para desempenharem um ou mais dos 3_ [_Papéis Essenciais Eleitos_][papeis-essenciais-eleitos]. O [Facilitador][facilitador] deverá conduzir o Modo Selecionar através de uma eleição democrática, onde a maioria dos votos determinará o [Parceiro][parceiros] eleito.
+O "Modo Selecionar" é um momento da [Reunião de Círculo][reunioes-de-circulo] cujo objetivo é _escolher_ [_Membros do Círculo_][membros-do-circulo] _para energizarem um ou mais dos 3_ [_Papéis Essenciais Eleitos_][papeis-essenciais-eleitos]. O [Facilitador][facilitador] deverá conduzir o Modo Selecionar através de uma eleição democrática, onde a maioria dos votos determinará o [Parceiro][parceiros] eleito.
 
 > Veja os **Padrões para Selecionar** na na [Biblioteca de Padrões][biblioteca]
 
@@ -98,14 +98,14 @@ O processo de eleição dos 3 [Papéis Essenciais Eleitos][papeis-essenciais-ele
 
 ### 4.7.3 <span id="parceiros-elegiveis">Parceiros elegíveis</span>
 
-Todos e apenas os [Membros do Círculo][membros-do-circulo] são elegíveis para os 3 [Papéis Essenciais Eleitos][papeis-essenciais-eleitos], com a exceção do [Parceiro][parceiros] que desempenha o [Papel][papeis] de [Elo Externo][elo-externo], que não é elegível como [Facilitador][facilitador] ou [Elo Interno][elo-interno] do mesmo [Círculo][circulos].
+Todos e apenas os [Membros do Círculo][membros-do-circulo] são elegíveis para os 3 [Papéis Essenciais Eleitos][papeis-essenciais-eleitos], com a exceção do [Parceiro][parceiros] que energiza o [Papel][papeis] de [Elo Externo][elo-externo], que não é elegível como [Facilitador][facilitador] ou [Elo Interno][elo-interno] do mesmo [Círculo][circulos].
 
 ### 4.7.4 <span id="desempate">Desempate</span>
 
 Em caso de empate na eleição de algum [Papel Essencial Eleito][papeis-essenciais-eleitos], o [Facilitador][facilitador] deverá escolher um dos seguintes critérios para desempatar:
 
 * O [Parceiro][parceiros] que nomeou a si mesmo, se apenas um dos candidatos empatados o fez;
-* O [Parceiro][parceiros] que já está desempenhando o [Papel][papeis], se apenas um dos candidatos empatados está;
+* O [Parceiro][parceiros] que já está energizando o [Papel][papeis], se apenas um dos candidatos empatados está;
 * Aleatoriamente escolher um dos candidatos empatados.
 
 ## 4.8 <span id="modo-cuidar">Modo Cuidar</span>

--- a/meta-acordos/reunioes-de-circulo.md
+++ b/meta-acordos/reunioes-de-circulo.md
@@ -1,115 +1,145 @@
 # 4. <span id="reunioes-de-circulo">Reuniões de Círculo</span>
 
-[Membros do Círculo](estrutura-organizacional.md#membros-do-circulo) regularmente se encontram em um espaço chamado "Reunião de Círculo" para executar um ou mais dos 5 "Modos" especiais de reunião descritos na seção seguinte: [Revisar](reunioes-de-circulo.md#modo-revisar), [Sincronizar](reunioes-de-circulo.md#modo-sincronizar), [Adaptar](reunioes-de-circulo.md#modo-adaptar), [Selecionar](reunioes-de-circulo.md#modo-selecionar) e [Cuidar](reunioes-de-circulo.md#modo-cuidar). Reuniões de Círculo são agendadas pelo [Secretário](papeis-essenciais.md#secretario) e facilitadas pelo [Facilitador](papeis-essenciais.md#facilitador), dois [Papéis Essenciais](reunioes-de-circulo.md#papeis-essenciais.md).
+[Membros do Círculo][membros-do-circulo] regularmente se encontram em um espaço chamado "Reunião de Círculo" para executar um ou mais dos 5 "Modos" especiais de reunião descritos na seção seguinte: [Revisar][modo-revisar], [Sincronizar][modo-sincronizar], [Adaptar][modo-adaptar], [Selecionar][modo-selecionar] e [Cuidar][modo-cuidar]. Reuniões de Círculo são agendadas pelo [Secretário][secretario] e facilitadas pelo [Facilitador][facilitador], dois [Papéis Essenciais][papeis-essenciais].
 
 ## 4.1 <span id="somente-membros-podem-processar-tensoes">Somente Membros podem processar tensões</span>
 
-[Parceiros](organizacao.md#parceiros) que não são [Membros do Círculo](estrutura-organizacional.md#membros-do-circulo) não podem processar [Tensões](organizacao.md#tensoes) nas [Reuniões de Círculo](reunioes-de-circulo.md#reunioes-de-circulo). No entanto, [Parceiros](organizacao.md#parceiros) podem ser convidadas por um [Membro do Círculo](estrutura-organizacional.md#membros-do-circulo) para ajudar no processamento de uma [Tensão](organizacao.md#tensoes) específica. Neste caso, a tensão a ser processada ainda será considerada do [Membro do Círculo](estrutura-organizacional.md#membros-do-circulo) e não do [Parceiros](organizacao.md#parceiros).
+[Parceiros][parceiros] que não são [Membros do Círculo][membros-do-circulo] não podem processar [Tensões][tensoes] nas [Reuniões de Círculo][reunioes-de-circulo]. No entanto, [Parceiros][parceiros] podem ser convidadas por um [Membro do Círculo][membros-do-circulo] para ajudar no processamento de uma [Tensão][tensoes] específica. Neste caso, a tensão a ser processada ainda será considerada do [Membro do Círculo][membros-do-circulo] e não do [Parceiros][parceiros].
 
 ## 4.2 <span id="formato-da-reuniao">Formato da Reunião</span>
 
-As [Reuniões de Círculo](reunioes-de-circulo.md#reunioes-de-circulo) devem começar com uma rodada de check-in, onde um por vez, cada participante compartilha como ele ou ela está chegando no encontro. O [Facilitador](papeis-essenciais.md#facilitador) preenche o encontro com um ou mais dos 5 [Modos](reunioes-de-circulo.md#reunioes-de-circulo), de acordo com o tempo disponível e as necessidades do [Círculo](estrutura-organizacional.md#circulos). O [Facilitador](papeis-essenciais.md#facilitador) deve declarar o nome, objetivo e esclarecer as regras de cada [Modo](reunioes-de-circulo.md#reunioes-de-circulo) antes de iniciá-lo. As [Reuniões de Círculo](reunioes-de-circulo.md#reunioes-de-circulo) terminam com uma rodada de encerramento, onde um por vez, cada participante compartilha uma reflexão final sobre o encontro.
+As [Reuniões de Círculo][reunioes-de-circulo] devem começar com uma rodada de check-in, onde um por vez, cada participante compartilha como ele ou ela está chegando no encontro. O [Facilitador][facilitador] preenche o encontro com um ou mais dos 5 [Modos][reunioes-de-circulo], de acordo com o tempo disponível e as necessidades do [Círculo][circulos]. O [Facilitador][facilitador] deve declarar o nome, objetivo e esclarecer as regras de cada [Modo][reunioes-de-circulo] antes de iniciá-lo. As [Reuniões de Círculo][reunioes-de-circulo] terminam com uma rodada de encerramento, onde um por vez, cada participante compartilha uma reflexão final sobre o encontro.
 
 ### 4.2.1 <span id="lista-de-tensoes">Lista de Tensões</span>
 
-Os diferentes [Modos](reunioes-de-circulo.md#reunioes-de-circulo) são utilizados para processar [Tensões](organizacao.md#tensoes) específicas sentidas pelos [Membros do Círculo](estrutura-organizacional.md#membros-do-circulo). Especialmente antes de [Sincronizar](reunioes-de-circulo.md#modo-sincronizar) e [Adaptar](reunioes-de-circulo.md#modo-adaptar), o [Facilitador](papeis-essenciais.md#facilitador) deve pedir para o [Secretário](papeis-essenciais.md#secretario) construir uma "Lista de Tensões" a processar. Cada [Membro do Círculo](estrutura-organizacional.md#membros-do-circulo) sentindo uma [Tensão](organizacao.md#tensoes) deve nomeá-la usando duas ou três palavras. O [Secretário](papeis-essenciais.md#secretario) então registra o nome da [Tensão](organizacao.md#tensoes), juntamente com o nome do [Parceiro](organizacao.md#parceiros).
+Os diferentes [Modos][reunioes-de-circulo] são utilizados para processar [Tensões][tensoes] específicas sentidas pelos [Membros do Círculo][membros-do-circulo]. Especialmente antes de [Sincronizar][modo-sincronizar] e [Adaptar][modo-adaptar], o [Facilitador][facilitador] deve pedir para o [Secretário][secretario] construir uma "Lista de Tensões" a processar. Cada [Membro do Círculo][membros-do-circulo] sentindo uma [Tensão][tensoes] deve nomeá-la usando duas ou três palavras. O [Secretário][secretario] então registra o nome da [Tensão][tensoes], juntamente com o nome do [Parceiro][parceiros].
 
 ### 4.2.2 <span id="uma-tensao-de-cada-vez">Uma Tensão de cada vez</span>
 
-Depois que a lista de [Tensões](organizacao.md#tensoes) for construída, o [Facilitador](papeis-essenciais.md#facilitador) deve focar em uma [Tensão](organizacao.md#tensoes) de cada vez. Isto significa que o [Facilitador](papeis-essenciais.md#facilitador) não deve permitir que outros participantes tentem incluir suas perspectivas na [Tensão](organizacao.md#tensoes) sendo processada, a não ser que o participante que sentiu a [Tensão](organizacao.md#tensoes) originalmente acredite que aquela perspectiva seja útil.
+Depois que a lista de [Tensões][tensoes] for construída, o [Facilitador][facilitador] deve focar em uma [Tensão][tensoes] de cada vez. Isto significa que o [Facilitador][facilitador] não deve permitir que outros participantes tentem incluir suas perspectivas na [Tensão][tensoes] sendo processada, a não ser que o participante que sentiu a [Tensão][tensoes] originalmente acredite que aquela perspectiva seja útil.
 
 ## 4.3 <span id="restricoes-de-facilitacao">Restrições de Facilitação</span>
 
-Durante a facilitação dos [Modos](reunioes-de-circulo.md#reunioes-de-circulo), o [Facilitador](papeis-essenciais.md#facilitador) pode fazer escolhas de que padrões utilizar e como conduzir cada momento. No entanto, o [Facilitador](papeis-essenciais.md#facilitador) deve sempre manter as suas escolhas alinhadas com o objetivo do [Modo](reunioes-de-circulo.md#reunioes-de-circulo) e as necessidades do [Círculo](estrutura-organizacional.md#circulos). Um [Círculo](estrutura-organizacional.md#circulos) pode também adotar uma ou mais [Restrições](estrutura-organizacional.md#restricoes) que limitem como os [Modos](reunioes-de-circulo.md#reunioes-de-circulo) são conduzidos. O [Facilitador](papeis-essenciais.md#facilitador) deve respeitar estas limitações.
+Durante a facilitação dos [Modos][reunioes-de-circulo], o [Facilitador][facilitador] pode fazer escolhas de que padrões utilizar e como conduzir cada momento. No entanto, o [Facilitador][facilitador] deve sempre manter as suas escolhas alinhadas com o objetivo do [Modo][reunioes-de-circulo] e as necessidades do [Círculo][circulos]. Um [Círculo][circulos] pode também adotar uma ou mais [Restrições][restricoes] que limitem como os [Modos][reunioes-de-circulo] são conduzidos. O [Facilitador][facilitador] deve respeitar estas limitações.
 
 ## 4.4 <span id="modo-revisar">Modo Revisar</span>
 
-O "Modo Revisar" é um momento da [Reunião de Círculo](reunioes-de-circulo.md#reunioes-de-circulo) cujo objetivo é _dar transparência ao trabalho realizado pelo_ [_Círculo_](estrutura-organizacional.md#circulos). Cabe ao [Facilitador](papeis-essenciais.md#facilitador) decidir como especificamente o [Modo Revisar](reunioes-de-circulo.md#modo-revisar) é conduzido, exceto se uma [Restrição](estrutura-organizacional.md#restricoes) determinar o contrário.
+O "Modo Revisar" é um momento da [Reunião de Círculo][reunioes-de-circulo] cujo objetivo é _dar transparência ao trabalho realizado pelo_ [_Círculo_][circulos]. Cabe ao [Facilitador][facilitador] decidir como especificamente o [Modo Revisar][modo-revisar] é conduzido, exceto se uma [Restrição][restricoes] determinar o contrário.
 
-> Veja os **Padrões para Revisar** na [Biblioteca de Padrões](../biblioteca/README.md).
+> Veja os **Padrões para Revisar** na [Biblioteca de Padrões][biblioteca]
 
 ## 4.5 <span id="modo-sincronizar">Modo Sincronizar</span>
 
-O "Modo Sincronizar" é um momento da [Reunião de Círculo](reunioes-de-circulo.md#reunioes-de-circulo) cujo objetivo é _rapidamente processar_ [_Tensões_](organizacao.md#tensoes) _que não exigem o_ [_Círculo_](estrutura-organizacional.md#circulos) _atualizar a sua_ [_Estrutura Organizacional_](estrutura-organizacional.md). Saídas típicas do _Modo Sincronizar_ incluem ações, projetos, pedidos de ajuda e compartilhamento de informações. O [Facilitador](papeis-essenciais.md#facilitador) deve simplesmente permitir que cada participante que trouxe uma [Tensão](organizacao.md#tensoes) engaje os outros nos seus [Papéis](estrutura-organizacional.md#papeis) e [Deveres](direitos-e-deveres.md), até que um caminho para resolver a [Tensão](organizacao.md#tensoes) seja identificado. O [Secretário](papeis-essenciais.md#secretario) deve registrar quaisquer pedidos aceitos pelos outros participantes em seus [Papéis](estrutura-organizacional.md#papeis) ou como Atos Heróicos.
+O "Modo Sincronizar" é um momento da [Reunião de Círculo][reunioes-de-circulo] cujo objetivo é _rapidamente processar_ [_Tensões_][tensoes] _que não exigem o_ [_Círculo_][circulos] _atualizar a sua_ [_Estrutura Organizacional_][estrutura-organizacional]. Saídas típicas do _Modo Sincronizar_ incluem ações, projetos, pedidos de ajuda e compartilhamento de informações. O [Facilitador][facilitador] deve simplesmente permitir que cada participante que trouxe uma [Tensão][tensoes] engaje os outros nos seus [Papéis][papeis] e [Deveres][direitos-e-deveres], até que um caminho para resolver a [Tensão][tensoes] seja identificado. O [Secretário][secretario] deve registrar quaisquer pedidos aceitos pelos outros participantes em seus [Papéis][papeis] ou como Atos Heróicos.
 
-> Veja os **Padrões para Sincronizar** na [Biblioteca de Padrões](../biblioteca/README.md).
+> Veja os **Padrões para Sincronizar** na [Biblioteca de Padrões][biblioteca]
 
 ## 4.6 <span id="modo-adaptar">Modo Adaptar</span>
 
-O "Modo Adaptar" é um momento da [Reunião de Círculo](reunioes-de-circulo.md#reunioes-de-circulo) cujo objetivo é _processar_ [_Tensões_](organizacao.md#tensoes) _em mudanças na_ [_Estrutura Organizacional_](estrutura-organizacional.md) _do_ [_Círculo_](estrutura-organizacional.md#circulos). As únicas saídas válidas e permitidas no [Modo Adaptar](reunioes-de-circulo.md#modo-adaptar) são:
+O "Modo Adaptar" é um momento da [Reunião de Círculo][reunioes-de-circulo] cujo objetivo é _processar_ [_Tensões_][tensoes] _em mudanças na_ [_Estrutura Organizacional_][estrutura-organizacional] _do_ [_Círculo_][circulos]. As únicas saídas válidas e permitidas no [Modo Adaptar][modo-adaptar] são:
 
-* Adicionar, remover ou alterar [Papéis](estrutura-organizacional.md#papeis) do [Círculo](estrutura-organizacional.md#circulos);
-* Adicionar, remover ou alterar [Círculos](estrutura-organizacional.md#circulos) internos;
-* Adicionar, remover ou alterar [Restrições](estrutura-organizacional.md#restricoes) do [Círculo](estrutura-organizacional.md#circulos);
-* Mover seus [Papéis](estrutura-organizacional.md#papeis), [Restrições](estrutura-organizacional.md#restricoes) ou [Círculos](estrutura-organizacional.md#circulos) internos para um [Círculo](estrutura-organizacional.md#circulos) interno;
-* Mover [Papéis](estrutura-organizacional.md#papeis), [Restrições](estrutura-organizacional.md#restricoes) ou [Círculos](estrutura-organizacional.md#circulos) de um [Círculo](estrutura-organizacional.md#circulos) interno para si;
-* Transformar os seus [Papéis](estrutura-organizacional.md#papeis) em [Círculos](estrutura-organizacional.md#circulos) internos, e vice-versa.
+* Adicionar, remover ou alterar [Papéis][papeis] do [Círculo][circulos];
+* Adicionar, remover ou alterar [Círculos][circulos] internos;
+* Adicionar, remover ou alterar [Restrições][restricoes] do [Círculo][circulos];
+* Mover seus [Papéis][papeis], [Restrições][restricoes] ou [Círculos][circulos] internos para um [Círculo][circulos] interno;
+* Mover [Papéis][papeis], [Restrições][restricoes] ou [Círculos][circulos] de um [Círculo][circulos] interno para si;
+* Transformar os seus [Papéis][papeis] em [Círculos][circulos] internos, e vice-versa.
 
 ### 4.6.1 <span id="proposta">Proposta</span>
 
-Durante o [Modo Adaptar](reunioes-de-circulo.md#modo-adaptar), o [Facilitador](papeis-essenciais.md#facilitador) deve facilitar um processo que permita ao participante que trouxe a [Tensão](organizacao.md#tensoes), o "Proponente", construir uma "Proposta" para resolvê-la. Esta Proposta deve conter somente as operações descritas como saídas válidas do [Modo Adaptar](reunioes-de-circulo.md#modo-adaptar).
+Durante o [Modo Adaptar][modo-adaptar], o [Facilitador][facilitador] deve facilitar um processo que permita ao participante que trouxe a [Tensão][tensoes], o "Proponente", construir uma "Proposta" para resolvê-la. Esta Proposta deve conter somente as operações descritas como saídas válidas do [Modo Adaptar][modo-adaptar].
 
 ### 4.6.2 <span id="apresentacao-de-exemplos">Apresentação de Exemplos</span>
 
-O [Proponente](reunioes-de-circulo.md#proposta) de uma mudança na [Estrutura Organizacional](estrutura-organizacional.md) deve ser capaz de apresentar exemplos de situações passadas ou presentes onde cada parte da [Proposta](reunioes-de-circulo.md#proposta) construída resolveria ou reduziria a [Tensão](organizacao.md#tensoes). Se o [Facilitador](papeis-essenciais.md#facilitador) considerar que o [Proponente](reunioes-de-circulo.md#proposta) não foi capaz de apresentar exemplos e esclarecimentos, o [Facilitador](papeis-essenciais.md#facilitador) deve descartar a [Proposta](reunioes-de-circulo.md#proposta). No entanto, o [Facilitador](papeis-essenciais.md#facilitador) não deve julgar a exatidão dos argumentos apresentados, mas somente se eles foram apresentados com um raciocínio lógico e são, portanto, plausíveis.
+O [Proponente][proposta] de uma mudança na [Estrutura Organizacional][estrutura-organizacional] deve ser capaz de apresentar exemplos de situações passadas ou presentes onde cada parte da [Proposta][proposta] construída resolveria ou reduziria a [Tensão][tensoes]. Se o [Facilitador][facilitador] considerar que o [Proponente][proposta] não foi capaz de apresentar exemplos e esclarecimentos, o [Facilitador][facilitador] deve descartar a [Proposta][proposta]. No entanto, o [Facilitador][facilitador] não deve julgar a exatidão dos argumentos apresentados, mas somente se eles foram apresentados com um raciocínio lógico e são, portanto, plausíveis.
 
 ### 4.6.3 <span id="objecoes">Objeções</span>
 
-O [Facilitador](papeis-essenciais.md#facilitador) deve permitir que cada participante tenha a oportunidade de levantar uma ou mais "Objeções" à [Proposta](reunioes-de-circulo.md#proposta) apresentada. Uma Objeção é uma razão pela qual a [Proposta](reunioes-de-circulo.md#proposta) causa mal e move o [Círculo](estrutura-organizacional.md#circulos) para trás. O [Facilitador](papeis-essenciais.md#facilitador) pode fazer perguntas para ajudar o "Objetor" a entender se o que ele trouxe são "Objeções Válidas" ou não.
+O [Facilitador][facilitador] deve permitir que cada participante tenha a oportunidade de levantar uma ou mais "Objeções" à [Proposta][proposta] apresentada. Uma Objeção é uma razão pela qual a [Proposta][proposta] causa mal e move o [Círculo][circulos] para trás. O [Facilitador][facilitador] pode fazer perguntas para ajudar o "Objetor" a entender se o que ele trouxe são "Objeções Válidas" ou não.
 
 ### 4.6.4 <span id="objecoes-validas">Objeções Válidas</span>
 
-Uma [Objeção](reunioes-de-circulo.md#objecoes) a uma [Proposta](reunioes-de-circulo.md#proposta) de mudança na [Estrutura Organizacional](estrutura-organizacional.md) é considerada válida caso o [Objetor](reunioes-de-circulo.md#objecoes) acredite que ela atenda a todos os 4 critérios a seguir:
+Uma [Objeção][objecoes] a uma [Proposta][proposta] de mudança na [Estrutura Organizacional][estrutura-organizacional] é considerada válida caso o [Objetor][objecoes] acredite que ela atenda a todos os 4 critérios a seguir:
 
-1. **Degradação**. A [Objeção](reunioes-de-circulo.md#objecoes) é sobre algum mal que a [Proposta](reunioes-de-circulo.md#proposta) poderia causar ao [Círculo](estrutura-organizacional.md#circulos).
-2. **Relacionada ao Papéis**. A [Objeção](reunioes-de-circulo.md#objecoes) afeta um dos [Papéis](estrutura-organizacional.md#papeis) do [Objetor](reunioes-de-circulo.md#objecoes) no [Círculo](estrutura-organizacional.md#circulos).
-3. **Causalidade**. Este mal é causado pela [Proposta](reunioes-de-circulo.md#proposta), ou seja, ele não existiria sem ela.
-4. **Baseada em dados**. A [Objeção](reunioes-de-circulo.md#objecoes) é baseada em dados atuais ou experiências passadas, portanto não é uma antecipação de eventos futuros. No entanto, se o dano alegado é tão desastroso que o [Círculo](estrutura-organizacional.md#circulos) não seria capaz de se adaptar no futuro, então este critério pode ser desconsiderado.
+1. **Degradação**. A [Objeção][objecoes] é sobre algum mal que a [Proposta][proposta] poderia causar ao [Círculo][circulos].
+2. **Relacionada ao Papéis**. A [Objeção][objecoes] afeta um dos [Papéis][papeis] do [Objetor][objecoes] no [Círculo][circulos].
+3. **Causalidade**. Este mal é causado pela [Proposta][proposta], ou seja, ele não existiria sem ela.
+4. **Baseada em dados**. A [Objeção][objecoes] é baseada em dados atuais ou experiências passadas, portanto não é uma antecipação de eventos futuros. No entanto, se o dano alegado é tão desastroso que o [Círculo][circulos] não seria capaz de se adaptar no futuro, então este critério pode ser desconsiderado.
 
-Ao validar [Objeções](reunioes-de-circulo.md#objecoes), o [Facilitador](papeis-essenciais.md#facilitador) não deve julgar a exatidão dos argumentos apresentados, mas somente se eles foram apresentados com um raciocínio lógico e são, portanto, plausíveis. [Objeções](reunioes-de-circulo.md#objecoes) válidas devem ser integradas.
+Ao validar [Objeções][objecoes], o [Facilitador][facilitador] não deve julgar a exatidão dos argumentos apresentados, mas somente se eles foram apresentados com um raciocínio lógico e são, portanto, plausíveis. [Objeções][objecoes] válidas devem ser integradas.
 
 ### 4.6.5 <span id="integracao">Integração</span>
 
-Se houver [Objeções](reunioes-de-circulo.md#objecoes), o [Facilitador](papeis-essenciais.md#facilitador) deve facilitar um processo para integrá-las à proposta, uma de cada vez. O objetivo da "Integração" é modificar a [Proposta](reunioes-de-circulo.md#proposta) para que ela resolva a [Tensão](organizacao.md#tensoes) original, mas sem causar a [Objeção](reunioes-de-circulo.md#objecoes) levantada. Se a [Proposta](reunioes-de-circulo.md#proposta) for alterada, o [Facilitador](papeis-essenciais.md#facilitador) deve dar mais uma oportunidade para os participantes levantarem [Objeções](reunioes-de-circulo.md#objecoes). Se uma [Proposta](reunioes-de-circulo.md#proposta) estiver levando muito tempo para integrar, o [Facilitador](papeis-essenciais.md#facilitador) pode descartar a [Proposta](reunioes-de-circulo.md#proposta) inteiramente, a fim de passar para o próximo item da [Lista de Tensões](reunioes-de-circulo.md#lista-de-tensoes).
+Se houver [Objeções][objecoes], o [Facilitador][facilitador] deve facilitar um processo para integrá-las à proposta, uma de cada vez. O objetivo da "Integração" é modificar a [Proposta][proposta] para que ela resolva a [Tensão][tensoes] original, mas sem causar a [Objeção][objecoes] levantada. Se a [Proposta][proposta] for alterada, o [Facilitador][facilitador] deve dar mais uma oportunidade para os participantes levantarem [Objeções][objecoes]. Se uma [Proposta][proposta] estiver levando muito tempo para integrar, o [Facilitador][facilitador] pode descartar a [Proposta][proposta] inteiramente, a fim de passar para o próximo item da [Lista de Tensões][lista-de-tensoes].
 
 ### 4.6.6 <span id="quebra-dos-meta-acordos">Quebra dos Meta-Acordos</span>
 
-Qualquer participante pode levantar uma [Objeção](reunioes-de-circulo.md#objecoes) de "Quebra dos Meta-Acordos" se ele ou ela considerar que a [Proposta](reunioes-de-circulo.md#proposta) viola uma das regras descritas nestes Meta-Acordos. O [Facilitador](papeis-essenciais.md#facilitador) deve então pedir ao [Secretário](papeis-essenciais.md#secretario) que interprete se isto é verdadeiro ou não. Esta [Objeção](reunioes-de-circulo.md#objecoes) especial não precisa ser validada com os critérios utilizados normalmente, mas deve ser integrada como as outras.
+Qualquer participante pode levantar uma [Objeção][objecoes] de "Quebra dos Meta-Acordos" se ele ou ela considerar que a [Proposta][proposta] viola uma das regras descritas nestes [Meta-Acordos][meta-acordos]. O [Facilitador][facilitador] deve então pedir ao [Secretário][secretario] que interprete se isto é verdadeiro ou não. Esta [Objeção][objecoes] especial não precisa ser validada com os critérios utilizados normalmente, mas deve ser integrada como as outras.
 
 ### 4.6.7 <span id="propostas-assincronas">Propostas Assíncronas</span>
 
-Alterações na [Estrutura Organizacional](estrutura-organizacional.md) do [Círculo](estrutura-organizacional.md#circulos) podem ser propostas fora da [Reunião de Círculo](reunioes-de-circulo.md#reunioes-de-circulo) e são automaticamente aprovadas se todos os [Membros do Círculo](estrutura-organizacional.md#membros-do-circulo) declararem que não têm qualquer [Objeção](reunioes-de-circulo.md#objecoes). Se qualquer [Objeção](reunioes-de-circulo.md#objecoes) for levantada ou um participante declarar que gostaria de tratar a [Tensão](organizacao.md#tensoes) de forma convencional, a [Proposta](reunioes-de-circulo.md#proposta) deve ser escalada para o [Modo Adaptar](reunioes-de-circulo.md#modo-adaptar) de uma [Reunião de Círculo](reunioes-de-circulo.md#reunioes-de-circulo) convencional.
+Alterações na [Estrutura Organizacional][estrutura-organizacional] do [Círculo][circulos] podem ser propostas fora da [Reunião de Círculo][reunioes-de-circulo] e são automaticamente aprovadas se todos os [Membros do Círculo][membros-do-circulo] declararem que não têm qualquer [Objeção][objecoes]. Se qualquer [Objeção][objecoes] for levantada ou um participante declarar que gostaria de tratar a [Tensão][tensoes] de forma convencional, a [Proposta][proposta] deve ser escalada para o [Modo Adaptar][modo-adaptar] de uma [Reunião de Círculo][reunioes-de-circulo] convencional.
 
-> Veja os **Padrões para Adaptar** na na [Biblioteca de Padrões](../biblioteca/README.md).
+> Veja os **Padrões para Adaptar** na na [Biblioteca de Padrões][biblioteca]
 
 ## 4.7 <span id="modo-selecionar">Modo Selecionar</span>
 
-O "Modo Selecionar" é um momento da [Reunião de Círculo](reunioes-de-circulo.md#reunioes-de-circulo) cujo objetivo é _escolher_ [_Membros do Círculo_](estrutura-organizacional.md#membros-do-circulo) _para desempenharem um ou mais dos 3_ [_Papéis Essenciais Eleitos_](papeis-essenciais.md#papeis-essenciais-eleitos). O [Facilitador](papeis-essenciais.md#facilitador) deverá conduzir o Modo Selecionar através de uma eleição democrática, onde a maioria dos votos determinará o [Parceiro](organizacao.md#parceiros) eleito.
+O "Modo Selecionar" é um momento da [Reunião de Círculo][reunioes-de-circulo] cujo objetivo é _escolher_ [_Membros do Círculo_][membros-do-circulo] _para desempenharem um ou mais dos 3_ [_Papéis Essenciais Eleitos_][papeis-essenciais-eleitos]. O [Facilitador][facilitador] deverá conduzir o Modo Selecionar através de uma eleição democrática, onde a maioria dos votos determinará o [Parceiro][parceiros] eleito.
 
-> Veja os **Padrões para Selecionar** na na [Biblioteca de Padrões](../biblioteca/README.md).
+> Veja os **Padrões para Selecionar** na na [Biblioteca de Padrões][biblioteca]
 
 ### 4.7.1 <span id="selecionar-imediatamente">Selecionar imediatamente</span>
 
-Qualquer [Membro do Círculo](estrutura-organizacional.md#membros-do-circulo) pode pedir para o [Facilitador](papeis-essenciais.md#facilitador) pular para o [Modo Selecionar](reunioes-de-circulo.md#modo-selecionar) e realizar uma eleição para um ou mais dos [Papéis Essenciais Eleitos](papeis-essenciais.md#papeis-essenciais-eleitos). Se este for o caso, o [Facilitador](papeis-essenciais.md#facilitador) deve fazer isso imediatamente.
+Qualquer [Membro do Círculo][membros-do-circulo] pode pedir para o [Facilitador][facilitador] pular para o [Modo Selecionar][modo-selecionar] e realizar uma eleição para um ou mais dos [Papéis Essenciais Eleitos][papeis-essenciais-eleitos]. Se este for o caso, o [Facilitador][facilitador] deve fazer isso imediatamente.
 
 ### 4.7.2 <span id="selecionar-apenas-em-reunioes-de-circulo">Selecionar apenas em Reuniões de Círculo</span>
 
-O processo de eleição dos 3 [Papéis Essenciais Eleitos](papeis-essenciais.md#papeis-essenciais-eleitos) deve ser feito apenas dentro de uma [Reunião de Círculo](reunioes-de-circulo.md#reunioes-de-circulo).
+O processo de eleição dos 3 [Papéis Essenciais Eleitos][papeis-essenciais-eleitos] deve ser feito apenas dentro de uma [Reunião de Círculo][reunioes-de-circulo].
 
 ### 4.7.3 <span id="parceiros-elegiveis">Parceiros elegíveis</span>
 
-Todos e apenas os [Membros do Círculo](estrutura-organizacional.md#membros-do-circulo) são elegíveis para os 3 [Papéis Essenciais Eleitos](papeis-essenciais.md#papeis-essenciais-eleitos), com a exceção do [Parceiro](organizacao.md#parceiros) que desempenha o [Papel](estrutura-organizacional.md#papeis) de [Elo Externo](papeis-essenciais.md#elo-externo), que não é elegível como [Facilitador](papeis-essenciais.md#facilitador) ou [Elo Interno](papeis-essenciais.md#elo-interno) do mesmo [Círculo](estrutura-organizacional.md#circulos).
+Todos e apenas os [Membros do Círculo][membros-do-circulo] são elegíveis para os 3 [Papéis Essenciais Eleitos][papeis-essenciais-eleitos], com a exceção do [Parceiro][parceiros] que desempenha o [Papel][papeis] de [Elo Externo][elo-externo], que não é elegível como [Facilitador][facilitador] ou [Elo Interno][elo-interno] do mesmo [Círculo][circulos].
 
 ### 4.7.4 <span id="desempate">Desempate</span>
 
-Em caso de empate na eleição de algum [Papel Essencial Eleito](papeis-essenciais.md#papeis-essenciais-eleitos), o [Facilitador](papeis-essenciais.md#facilitador) deverá escolher um dos seguintes critérios para desempatar:
+Em caso de empate na eleição de algum [Papel Essencial Eleito][papeis-essenciais-eleitos], o [Facilitador][facilitador] deverá escolher um dos seguintes critérios para desempatar:
 
-* O [Parceiro](organizacao.md#parceiros) que nomeou a si mesmo, se apenas um dos candidatos empatados o fez;
-* O [Parceiro](organizacao.md#parceiros) que já está desempenhando o [Papel](estrutura-organizacional.md#papeis), se apenas um dos candidatos empatados está;
+* O [Parceiro][parceiros] que nomeou a si mesmo, se apenas um dos candidatos empatados o fez;
+* O [Parceiro][parceiros] que já está desempenhando o [Papel][papeis], se apenas um dos candidatos empatados está;
 * Aleatoriamente escolher um dos candidatos empatados.
 
 ## 4.8 <span id="modo-cuidar">Modo Cuidar</span>
 
-O "Modo Cuidar" é um momento da [Reunião de Círculo](reunioes-de-circulo.md#reunioes-de-circulo) cujo objetivo é _estimular a presença e a conexão entre os participantes_. Este [Modo](reunioes-de-circulo.md#reunioes-de-circulo) não deve ser utilizado para fazer alterações na [Estrutura Organizacional](reunioes-de-circulo.md#modo-cuidar) do [Círculo](estrutura-organizacional.md#circulos) ou engajar os [Parceiros](organizacao.md#parceiros) nos seus [Papéis](estrutura-organizacional.md#papeis) e [Deveres](direitos-e-deveres.md).
+O "Modo Cuidar" é um momento da [Reunião de Círculo][reunioes-de-circulo] cujo objetivo é _estimular a presença e a conexão entre os participantes_. Este [Modo][reunioes-de-circulo] não deve ser utilizado para fazer alterações na [Estrutura Organizacional][modo-cuidar] do [Círculo][circulos] ou engajar os [Parceiros][parceiros] nos seus [Papéis][papeis] e [Deveres][direitos-e-deveres].
 
-> Veja os **Padrões para Cuidar** na [Biblioteca de Padrões](../biblioteca/README.md).
+> Veja os **Padrões para Cuidar** na [Biblioteca de Padrões][biblioteca]
+
+<!-- Links -->
+[meta-acordos]: README.md
+[reunioes-de-circulo]: reunioes-de-circulo.md
+[modo-revisar]: reunioes-de-circulo.md#modo-revisar
+[modo-sincronizar]: reunioes-de-circulo.md#modo-sincronizar
+[modo-adaptar]: reunioes-de-circulo.md#modo-adaptar
+[modo-selecionar]: reunioes-de-circulo.md#modo-selecionar
+[modo-cuidar]: reunioes-de-circulo.md#modo-cuidar
+[lista-de-tensoes]: reunioes-de-circulo.md#lista-de-tensoes
+[proposta]: reunioes-de-circulo.md#proposta
+[objecoes]: reunioes-de-circulo.md#objecoes
+[parceiros]: organizacao.md#parceiros
+[tensoes]: organizacao.md#tensoes
+[proposito-evolutivo]: organizacao.md#proposito-evolutivo
+[organizacao]: organizacao.md
+[direitos-e-deveres]: direitos-e-deveres.md
+[estrutura-organizacional]: estrutura-organizacional.md
+[circulos]: estrutura-organizacional.md#circulos
+[membros-do-circulo]: estrutura-organizacional.md#membros-do-circulo
+[papeis]: estrutura-organizacional.md#papeis
+[restricoes]: estrutura-organizacional.md#restricoes
+[modo-adaptar]: reunioes-de-circulo.md#modo-adaptar
+[papeis-essenciais]: papeis-essenciais.md
+[papeis-essenciais-eleitos]: papeis-essenciais.md#papeis-essenciais-eleitos
+[elo-externo]: papeis-essenciais.md#elo-externo
+[elo-interno]: papeis-essenciais.md#elo-interno
+[facilitador]: papeis-essenciais.md#facilitador
+[secretario]: papeis-essenciais.md#secretario
+[biblioteca]: ../biblioteca/README.md


### PR DESCRIPTION
Links refatorados e movidos para o rodapé para facilitar a edição daqui para frente. Os links tinham sido bagunçados e alterados pelo Gitbook, portanto a mudança teve que ser repetida.