### PR TITLE
Update meta-agreements.md to O2 v3.5

### DIFF
--- a/EN/meta-agreements.md
+++ b/EN/meta-agreements.md
@@ -1,355 +1,436 @@
-# 1. Organization
+# Meta-Agreements of the Organic Organization
 
-The "Organization" is an entity created to express an Evolutionary Purpose. An Organization has assets that it controls and a clear border with the outside world.
+Organic Organization (O2) is a catalyst that helps organizations adopt self-management. O2 consists of its [Meta-Agreements][meta-agreements] described in this document, along with a Pattern Library in constant evolution.
 
+A "Meta-Agreement" is an agreement for forming new agreements. This document describes the initial [Meta-Agreements][meta-agreements] of the Organic Organization, each identified by a title and description. The [Meta-Agreements][meta-agreements] have hyperlinks to each other to demonstrate their interdependence.
 
-# **1.1 Evolutionary Purpose**
+## Adoption
 
-The Organization, which corresponds to the deepest creative potential that it can express in a sustainable way in the world. The Evolutionary Purpose is the Purpose of the wider Circle of the Organizational Structure.) has an "Evolutionary Purpose", which corresponds to the deepest creative potential that it can express in a sustainable way in the world. The Evolutionary Purpose is the Purpose of the largest Circle of the Organizational Structure.
+This document does not define how the [Meta-Agreements][meta-agreements] are adopted, how they can be modified, or what is the [Purpose][purpose] of the [Organization][organization]. This is typically established through a social contract, statute, or agreement between a group of people who created the organizational entity.
 
+# 1 Organization
 
-# **1.2 Partners**
+The "Organization" is an entity created to express a [Purpose][purpose]. An Organization has assets that it controls and a clear boundary with the outside world.
 
-"Partners" are people who dedicate their time and energy to help the Organization express its Evolutionary Purpose.
+## 1.1 Purpose
 
+Purpose is a phrase that expresses the [Organization's][organization] reason for existing. The organization of internal circles and roles must contribute to this purpose.
 
-# **1.3 Creative Tensions**
+## 1.2 Partners
 
-While working for the Organization, Partners can identify a difference between the current reality and a potential that they perceive. These gaps, which can be identified problems or opportunities, are called "Creative Tensions", or simply "Tensions". Tensions move the Organization towards its Evolutionary Purpose.
+The "Partners" are those who dedicate their time and energy to help the [Organization][organization] express its [Purpose][purpose].
 
+## 1.3 Creative Tensions
 
-# **1.4 Self Responsibility**
+While working for the [Organization][organization], [Partners][partners] may identify a difference between current reality and a potential they perceive. These gaps, which can be problems or opportunities identified, are called "Creative Tensions", or simply "Tensions". Tensions move the [Organization][organization] toward its [Purpose][purpose].
 
-As a Partner, you are responsible for addressing the Tensions you perceive, taking actions or engaging other Partners in these Meta-Agreements. You are also expected to ask for help when you don't know which paths to take. This responsibility cannot be transferred to third parties or to a group.
+## 1.4 Legal Authorities
 
+These [Meta-Agreements][meta-agreements] do not automatically change decisions and authorities established by legal devices. For a legally assigned authority to a specific person or group to be delegated to other elements of the [Organizational Structure][organizational-structure], this must be done explicitly. In other words, a [Partner][partners] is not authorized to make decisions that require legal representation of the organization unless it is explicitly described in the [Organizational Structure][organizational-structure] that they may do so.
 
-# **1.5 Transparency**
+# 2 Organizational Structure
 
-As a Partner, you are expected to share, when asked by other Partners, all relevant information about the work you do for the Organization, including your projects, identified actions, prioritization criteria and relevant metrics. When requested, you are also expected to provide estimates and projections of possible completion dates for your work, even if these projections should not be considered deadlines or commitments.
+[Partners][partners] can define a layer of agreements that establishes expectations and limitations of authority between them. This layer, called "Organizational Structure", is organized in a hierarchy of [Circles][circles] and formed by [Roles][roles] and [Restrictions][restrictions]. Each [Circle][circles] governs its [Organizational Structure][organizational-structure], which can only be changed as described in the [Adapt][adapt] Interaction.
 
+## 2.1 Roles
 
-# **1.6 Heroic Act**
+[Partners][partners] execute work in one or more "Roles" explicitly defined in the [Organizational Structure][organizational-structure]. A Role is defined by:
 
-You can temporarily ignore these Meta-Agreements if this is useful and necessary to express the Evolutionary Purpose of the Organization. Initiatives or requests that have this quality are called "Heroic Acts". You should always seek to repair any damage caused after a Heroic Act, proposing changes in the Organizational Structure or even in these Meta-Agreements if necessary.
+* A descriptive name;
+* A "Purpose", which is an unattainable capacity, potential, or goal that the Role will pursue or express;
+* Zero or more "Responsibilities", which are ongoing activities that other [Partners][partners] can expect the Role to execute;
+* Zero or more "Artifacts", which are assets that the Role can exclusively control and regulate on behalf of the [Organization][organization].
 
-# 2. Organizational Structure
+### 2.1.1 Energization
 
-Partners can define a layer of agreements that establish expectations and limitations of authority between them. This layer, called "Organizational Structure", is organized in a hierarchy of Circles and formed by Roles and Policies. Each Circle governs its Organizational Structure, which can only be changed in Adapt Mode.
+"Energization" refers to which [Partners][partners] dedicate their time and energy to expressing the [Purpose][roles] of which [Roles][roles]. Energization is not a component of the [Organizational Structure][organizational-structure], although it may determine how and under what conditions it occurs.
 
+### 2.1.2 Role Authority
 
-# **2.1 Roles**
+When pursuing the [Purpose][roles] of the [Roles][roles] you energize, you are always authorized to take action. However, you must not impact the [Artifacts][roles] defined in [Roles][roles] that you do not energize or [Circle Artifacts][circle-artifacts] that you are not a [Member][circle-members] of, without first obtaining explicit permission from the responsible [Partner][partners]. You must also observe the [Restrictions][restrictions] defined in the [Organizational Structure][organizational-structure] and follow the conditions established therein.
 
-Partners perform work in one or more "Roles" explicitly defined in the Organizational Structure. A Role is defined by:
+You may also refuse a request if you interpret that it is not part of the scope of the [Roles][roles] you energize, that is, there is no corresponding explicit [Responsibility][roles] and it is not included in the [Purpose][roles].
 
+### 2.1.3 Leaving Roles
 
+You may at any time stop energizing [Roles][roles] in one or more [Circles][circles], unless you have otherwise agreed with the [Guide][guide] or another [Energization][energization] process.
 
-*   A descriptive name;
-*   A "Purpose", which is an unattainable capacity, potential or objective that the Paper will pursue or express;
-*   Zero or more "Responsibilities", which are ongoing activities that other Partners can expect the Role to perform;
-*   Zero or more "Artifacts", which are assets that the Paper can exclusively control and regulate on behalf of the Organization.
+## 2.2 Circles
 
+A "Circle" is a [Role][roles] that has the authority to divide into smaller [Roles][roles], contained within itself. When a [Role][roles] is transformed into a Circle, the [Partners][partners] who energize it become the [Guide][guide] of that [Circle][circles]. [Circles][circles] are defined exactly like [Roles][roles], that is, through the elements name, [Purpose][roles], [Responsibilities][roles] and [Artifacts][roles].
 
-## **2.1.1 Energizing Roles**
+### 2.2.1 Circles don't change their definition
 
-"Energizing" refers to that which Partners devote their time and energy to, in order to express the Purpose of their Roles. To energize is not a component of the Organizational Structure, although it can determine how and under what conditions it occurs.
+A [Circle][circles] can govern its own [Roles][roles] and [Restrictions][restrictions], but cannot change its own definition, as this must be done in the external [Circle][circles] that contains this [Circle][circles].
 
+### 2.2.2 Circles don't structure their internal Circles
 
-## **2.1.2 Role Authority**
+A [Circle][circles] cannot alter the [Roles][roles], [Circles][circles] and [Restrictions][restrictions] of an internal [Circle][circles] directly. However, a [Circle][circles] can perform some operations described in the [Adapt][adapt] Interaction, such as moving [Roles][roles] from itself to its internal [Circles][circles] and vice versa.
 
-When pursuing the Role's Purpose that you energize, you are always allowed to take action. However, you must not impact the Artifacts defined in Roles that you do not energize or Circle Artifacts that you are not a Member of, without first obtaining explicit permission from the Responsible Partner. You must also observe the Policies defined in the Organizational Structure and follow the conditions established therein.
+## 2.3 Circle Artifacts
 
-You can also refuse a request if there is no corresponding explicit accountability in the description of the Role being requested. Still, you must accept any requests that make sense for the Purpose of any of the Roles that you energize.
+When a [Circle][circles] has [Artifacts][roles] in its definition, only [Circle Members][circle-members] and internal [Circle][circles] Members can impact these [Artifacts][roles] freely.
 
+### 2.3.1 Circles can delegate Artifacts
 
-## **2.1.3 Leaving Roles**
+A [Circle][circles] can specify one of its [Artifacts][roles] in an internal [Role][roles] or [Circle][circles]. If this is done, that [Artifact][roles] becomes exclusive to the [Role][roles] or internal [Circle][circles], until this delegation is undone.
 
-You may, at any time, stop energizing Roles in one or more Circles, unless you have agreed to do otherwise with the External Link or to another Energization process.
+## 2.4 Circle Members
 
+[Partners][partners] are considered "Members" of a given [Circle][circles] when they meet at least one of the criteria below:
 
-# **2.2 Circles**
+* Energize at least one [Role][roles] defined in the [Circle][circles];
+* Energize at least one of the [Essential Roles][essential-roles] in the [Circle][circles];
+* Energize the [Role][roles] of [Guide][guide] or [Representative][representative] in at least one of the [Circles][circles] internal to the [Circle][circles].
 
-A "Circle" is a Role that has the authority to divide into smaller Roles, contained within itself. When a Role is transformed into a Circle, the Partners that energize it become the External Link of that Circle. Circles are defined exactly like Roles, that is, through the elements name, Purpose, Responsibilities and Artifacts.
+## 2.5 Restrictions
 
+A restriction is an agreement, specific to [Circles][circles], that limits how a process must happen or how an artifact must be used. A restriction has a title and a description, and its effect applies to all roles in that [Circle][circles] and to all its internal [Circles][circles], unless its description defines something different.
 
-## **2.2.1 Circles don't change their definition**
+### 2.5.1 Restrictions don't establish responsibilities
 
-A Circle can govern its own Roles and Restrictions, but it cannot change its own definition (purpose, responsibilities or artifacts), this must be done in the outer or external Circle that contains in it this inner or internal Circle.
+[Restrictions][restrictions] cannot establish responsibilities, because this is the purpose of a role. Still, a [Restriction][restrictions] can require action, but only for [Partners][partners] to whom the [Restriction][restrictions] applies.
 
+## 2.6 Circle Priorities
 
-## **2.2.2 Circles don't structure their internal Circles**
+A [Circle][circles] can establish priorities to guide the work of its [Members][circle-members]. As a [Circle Member][circle-members], you must prioritize your work in alignment with these established guidelines.
 
-A Circle cannot change the roles, Circles and Restrictions of an inner Circle directly. However, a Circle can perform some operations in Adapt Mode, such as moving Roles from itself to its internal Circles and vice versa.
+# 3. Meetings and Interactions
 
+To perceive and process [Tensions][tensions], [Partners][partners] can make use of some "Interactions" defined in this section.
 
-# **2.3 A Circle's Artifacts**
+## 3.1 Review
 
-When a Circle has Artifacts in its definition, only Members of the Circle and internal Circles can impact these Artifacts freely.
+In the "Review" interaction, two or more [Partners][partners] share and request information about work performed from their different [Roles][roles]. The objective of the Review interaction is to perceive [Tensions][tensions] from an inspection of the work.
 
+## 3.2 Synchronize
 
-## **2.3.1 Circles can delegate Artifacts**
+In the "Synchronize" interaction, two or more [Partners][partners] seek to process [Tensions][tensions] by engaging each other in the [Roles][roles] they energize. The Synchronize interaction happens based on the defined [Organizational Structure][organizational-structure] and can be used to request specific projects and actions for [Partners][partners] in their roles or [Heroic Acts][heroic-act].
 
-A Circle can specify one of its Artifacts as pertaining to a particular Role or Inner Circle. If this is done, that Artifact becomes exclusive to the Role or Inner Circle, until this delegation is undone.
+## 3.3 Adapt
 
+In the "Adapt" interaction, [Circle Members][circle-members] seek to resolve [Tensions][tensions] that involve changes in the [Organizational Structure][organizational-structure]. Each [Circle Member][circle-members] sensing a [Tension][tensions] can present or build a [Proposal][proposal] involving the [Adapt Operations][adapt-operations] and must use the [Integrative Decision][integrative-decision] to process it.
 
-# **2.4 Circle Members**
+### 3.3.1 Adapt Operations
 
-Partners are considered "Members" of a given Circle when they meet at least one of the criteria below:
+An [Adapt][adapt] [Proposal][proposal] can only include one or more of the operations described below:
 
-Energize at least one Role defined in the Circle;
+* Add, remove or alter [Circle][circles] [Roles][roles];
+* Add, remove or alter internal [Circles][circles];
+* Add, remove or alter [Circle][circles] [Restrictions][restrictions];
+* Move its [Roles][roles], [Restrictions][restrictions] or internal [Circles][circles] to an internal [Circle][circles];
+* Move [Roles][roles], [Restrictions][restrictions] or [Circles][circles] from an internal [Circle][circles] to itself;
+* Transform its [Roles][roles] into internal [Circles][circles], and vice versa.
 
-Energize at least one of the Essential Roles in the Circle;
+### 3.3.2 Integrative Decision
 
-Energize the Role of External Link or Internal Link in at least one of the Circles internal to the Circle.
+To process [Proposals][proposal] in [Adapt][adapt], [Circle Members][circle-members] must use the "Integrative Decision". During this decision-making process, the [Partner][partners] sensing the [Tension][tensions] presents a [Proposal][proposal] and seeks to integrate possible [Objections][objections] from all [Circle Members][circle-members]. The presented [Proposal][proposal] will only be considered accepted after all valid [Objections][objections] are integrated, discarded or abandoned.
 
+#### 3.3.2.1 Proposal
 
-# **2.5 Restrictions**
+A [Proposal][proposal] is a strategy described by a [Partner][partners], called the "Proposer", to address a [Tension][tensions] felt by them or someone they represent. Building the [Proposal][proposal] is the responsibility of the Proposer, although they may ask for help or consult opinions from other [Partners][partners] during the process.
 
-"Restrictions" are limitations of authority that apply to all Roles in a Circle. Restrictions are made up of a name and a description. Unless otherwise specified in its description, the effect of a Restriction applies to all Roles and Circles within the Circle where it is defined. A Restriction is part of a Circle, just like a Role or Inner Circle.
+#### 3.3.2.2 Presenting Examples
 
+The Proposer must be able to present examples of past or present situations where each part of the constructed [Proposal][proposal] would address the [Tension][tensions].
 
-# **2.6 Circle Priorities**
+#### 3.3.2.3 Facilitator may discard the Proposal
 
-A Circle can establish priorities to guide the work of its Members. As a Circle Member, you must prioritize your work in alignment with the established guidelines.
+When facilitating an [Integrative Decision][integrative-decision] in a [Circle Meeting][circle-meeting], if the [Facilitator][facilitator] considers that the Proposer was unable to present examples and clarifications of how the [Proposal][proposal] resolves the [Tension][tensions], the [Facilitator][facilitator] must discard the [Proposal][proposal]. The [Facilitator][facilitator] must not judge the accuracy of the arguments presented, but only if they were presented with logical reasoning and are, therefore, plausible.
 
+#### 3.3.2.4 Objections
 
-# 3. Circle Meetings
+During an [Integrative Decision][integrative-decision], [Circle Members][circle-members] can present one or more "Objections" to the [Proposal][proposal]. An Objection is a reason why the [Proposal][proposal] causes harm and impairs the [Partner's][partners] capacity to express the [Purpose][roles] of some [Role][roles] they represent.
 
-Circle members regularly meet in what is called the "Circle Meeting" to perform one or more of the 4 special meeting "Modes" described in the following section: Review, Synchronize, Adapt and Care. Circle meetings are scheduled by the Secretary and facilitated by the Facilitator, two Essential Roles.
+#### 3.3.2.5 Valid Objections
 
+An [Objection][objections] is considered valid if the [Partner][partners] who raised it believes it has all 4 characteristics below:
 
-# **3.1 Only Members can process tensions**
+1. **Harmful**: The [Objection][objections] is about some harm that the [Proposal][proposal] causes, and not just an opportunity for improvement in the [Proposal][proposal].
+2. **Direct**: The [Objection][objections] affects the [Partner's][partners] capacity to express the [Purpose][roles] of one of the [Roles][roles] they energize.
+3. **Causal**: The [Objection][objections] is caused by the [Proposal][proposal], that is, it doesn't exist if the [Proposal][proposal] is not adopted.
+4. **Factual**: The [Objection][objections] is based on current data or past experiences, therefore not an anticipation of future events. However, if the alleged harm is so disastrous that it would not be possible to adapt in the future, then this criterion can be disregarded.
 
-Partners who are not Circle Members cannot process tensions at Circle Meetings. However, Partners may be invited by a Circle Member to assist in processing a specific tension. In this case, the tension to be processed will still be considered by the Circle Member and not by the Partners.
+#### 3.3.2.6 Facilitator may discard the Objection
 
+When facilitating an [Integrative Decision][integrative-decision], if the [Facilitator][facilitator] considers that the [Partner][partners] was unable to present examples and clarifications of how the [Objection][objections] meets the [Valid Objections][valid-objections] criteria, the [Facilitator][facilitator] must discard the [Objection][objections]. The [Facilitator][facilitator] must not judge the accuracy of the arguments presented, but only if they were presented with logical reasoning and are, therefore, plausible.
 
-# **3.2 Meeting Format**
+#### 3.3.2.7 Integration
 
-Circle Meetings must start with a check-in round, where one at a time, each participant shares how he or she is. The Facilitator fills the meeting with one or more of the 4 Modes, according to the time available and the needs of the Circle. The Facilitator must declare the name, objective and clarify the rules of each Mode before starting it. The Circle Meetings end with a closing round, where one at a time, each participant shares a final reflection on the meeting.
+If there are [Objections][objections], the Proposer must integrate them into the [Proposal][proposal], one at a time. The goal of "Integration" is to modify the [Proposal][proposal] so that it resolves the original [Tension][tensions], but without causing the raised [Objection][objections]. If the [Proposal][proposal] is changed, the Proposer must give another opportunity for participants to raise [Objections][objections].
 
+During Integration, the [Facilitator][facilitator] may also discard the [Objection][objections] entirely if they judge that the person who raised it is not making a genuine effort to help the Proposer find a new [Proposal][proposal]. If a [Proposal][proposal] is taking too long to integrate, the [Facilitator][facilitator] may discard the [Proposal][proposal] entirely, in order to move to the next item on the [Tensions List][tension-list].
 
-## **3.2.1 The Tension Backlog**
+#### 3.3.2.8 Breaking the Meta-Agreements
 
-The different Modes are used to process specific Tensions felt by Circle Members. Especially before Synchronizing and Adapting, the Facilitator should ask the Secretary to build a "List of Tensions" to be processed. Each Circle Member feeling a Tension must name it using two or three words. The Secretary then records the name of the Tension, along with the name of the Partner.
+Any [Circle Member][circle-members] participating in an [Integrative Decision][integrative-decision] can raise a "Breaking the Meta-Agreements" [Objection][objections] if they consider that the [Proposal][proposal] violates a [Meta-Agreement][meta-agreements]. This special [Objection][objections] does not need to be validated with the criteria normally used but must be integrated like the others.
 
+## 3.4 Care
 
-## **3.2.2 One Tension at a Time**
+In the "Care" interaction, two or more [Partners][partners] seek to become present and deeply connect through empathic listening. During the Care interaction, [Partners][partners] set aside their [Roles][roles] to be integrally present as people. This interaction can be used to help a [Partner][partners] understand or explore an emotionally charged [Tension][tensions], or simply provide a space for support and free speech from the [Organizational Structure][organizational-structure].
 
-After the Tensions are listed, the Facilitator focuses on one Tension at a time. This means that the Facilitator should not allow other participants to attempt to include their perspectives in the Tension being processed, unless the participant who originally felt the Tension believes that perspective is useful.
+## 3.5 Circle Meeting
 
+A "Circle Meeting" is a space where [Members][circle-members] can meet regularly to interact, perceive and process [Tensions][tensions]. Circle Meetings are scheduled by the [Clerk][clerk] and facilitated by the [Facilitator][facilitator], two [Essential Roles][essential-roles].
 
-# **3.3 Facilitation Restrictions**
+### 3.5.1 Only Members can process Tensions
 
-When facilitating Modes, the Facilitator can make choices about which patterns to use and how to conduct each moment. However, the Facilitator must always keep his choices in line with the objective of the Mode and the needs of the Circle. A Circle may also adopt one or more Restriction that limits how the Modes are conducted. The Facilitator must respect these limitations.
+[Partners][partners] who are not [Circle Members][circle-members] cannot process [Tensions][tensions] in [Circle Meetings][circle-meeting]. However, other [Partners][partners] can be invited by a [Circle Member][circle-members] to help with a specific [Tension][tensions]. In this case, the tension will still be considered the [Circle Member's][circle-members] and not the invited [Partner's][partners].
 
+### 3.5.2 Meeting Format
 
-## **3.3.1 Elections are a Priority**
+[Circle Meetings][circle-meeting] begin with a check-in round, where one at a time, each participant shares how they are arriving at the meeting. The [Facilitator][facilitator] fills the meeting with the [Interactions][meetings-and-interactions] defined in this section or in the [Organizational Structure][organizational-structure], according to the time available and the [Circle's][circles] needs. [Circle Meetings][circle-meeting] end with a closing round, where one at a time, each participant shares a final reflection on the meeting.
 
-If any Circle Member requests the Election of any of the Essential Elected Roles, the Facilitator must prioritize that Tension by addressing it before any other.
+### 3.5.3 Absent Members
 
+During the [Circle Meeting][circle-meeting], one or more [Partners][partners] may present [Proposals][proposal] using the [Integrative Decision][integrative-decision]. If a [Partner][partners] is not present at the meeting, the [Proposal][proposal] proceeds as if the absent person had no [Objection][objections].
 
-# **3.4 Review Mode**
+### 3.5.4 Prioritize the Meeting
 
-The "Review Mode" is a moment of the Circle Meeting whose objective is to give transparency to the work done by the Circle. It is up to the Facilitator to decide how specifically the Review Mode is conducted, unless a Restriction determines otherwise.
+When requested by another [Member][circle-members] of a [Circle][circles] of which you are part, you must prioritize participating in the [Circle Meeting][circle-meeting] over working in your [Roles][roles].
 
-See the Patterns to Review in the Patterns Library
+## 3.6 Facilitation Restrictions
 
+During the facilitation of [Interactions][meetings-and-interactions], the [Facilitator][facilitator] can make choices about which patterns to use and how to conduct each moment. However, the [Facilitator][facilitator] must always keep their choices aligned with the objective of each [Interaction][meetings-and-interactions] and the needs of the [Circle][circles]. A [Circle][circles] can also adopt one or more [Restrictions][restrictions] that limit how the [Interactions][meetings-and-interactions] are conducted. The [Facilitator][facilitator] must respect these limitations.
 
-# **3.5 Sincronize Mode**
+### 3.6.1 One Tension at a time
 
-The "Synchronize Mode" is a moment of the Circle Meeting whose objective is to quickly process Tensions that do not require the Circle to update its Organizational Structure. Typical Sync Mode outputs include actions, projects, help requests and information sharing. The Facilitator should simply allow each participant who brought a Tension to engage others in their Roles until a path to resolve the Tension is identified. The Secretary records any requests accepted by other participants in their Roles or as Heroic Acts.
+When facilitating the [Circle Meeting][circle-meeting], the [Facilitator][facilitator] must focus attention on one [Tension][tensions] at a time. This means that the [Facilitator][facilitator] must not allow other participants to try to include their perspectives in the [Tension][tensions] being processed, unless the participant who felt the original [Tension][tensions] believes that perspective is useful and desirable.
 
-See the Patterns to Review in the Patterns Library
+### 3.6.2 Tension List
 
+To facilitate the processing of one [Tension][tensions] at a time, the [Facilitator][facilitator] may ask the [Clerk][clerk] to build a "Tension List" to process. Each [Circle Member][circle-members] feeling a [Tension][tensions] can then name it using a few words. The [Clerk][clerk] then records the name of the [Tension][tensions], along with the [Partner's][partners] name, so that the [Facilitator][facilitator] can go through it.
 
-# **3.6 Adapt Mode**
+## 3.7 Asynchronous Interactions
 
-The "Adapt Mode" is a moment that occurs in Circle Meeting. The objective is to process Tensions related to the Organizational Structure of the Circle. The only valid and permissible outputs in Adapt Mode are:
+The [Interactions][meetings-and-interactions] described in this section can happen outside a [Circle Meeting][circle-meeting] and in this case are considered "Asynchronous Interactions". If a [Partner][partners] presents a [Proposal][proposal] using the [Integrative Decision][integrative-decision] in these circumstances, any [Circle Member][circle-members] can escalate the [Proposal][proposal] to a conventional [Circle Meeting][circle-meeting]. The process of asynchronous interactions can be specified as a [Circle][circles] [Restriction][restrictions].
 
+## 3.8 New Interactions
 
+As a [Partner][partners] energizing [Roles][roles], you can create and use new types of [Interactions][meetings-and-interactions] beyond those defined in this section. However, any expectations or limitations of authority must be recorded in the [Organizational Structure][organizational-structure], in the form of [Roles][roles], [Circles][circles] and [Restrictions][restrictions].
 
-*   Add, remove or change Circle Roles;
-*   Add, remove or change Internal circles;
-*   Add, remove or change Circle Restrictions;
-*   Move your Roles, Restrictions or Inner Circles to an Inner Circle;
-*   Move Roles, Restrictions or Circles from an inner Circle to you;
-*   Transform your Roles into Inner Circles, and vice versa.
+# 4 Essential Roles
 
+Each [Circle][circles] contains "Essential Roles", called [Guide][guide], [Representative][representative], [Facilitator][facilitator] and [Clerk][clerk].
 
-## **3.6.1 Proposal**
+## 4.1 Guide
 
-During Adapt Mode, the Facilitator must facilitate a process that allows the participant who brought the Tension, the "Proponent", to build a "Proposal" to resolve it. This Proposal must contain only the operations described as valid outputs from Adapt Mode.
+The "Guide" [Role][roles] has the following initial definition:
 
+**Purpose**: _The [Purpose][roles] of the [Circle][circles]_
 
-## **3.6.2 Presenting Examples**
+**Responsibilities**:
+* Structure the [Circle][circles] to express its [Purpose][roles] and meet the [Responsibilities][roles] defined by the external [Circle][circles]
+* Invite [Partners][partners] to energize [Roles][roles] defined in the [Circle][circles]
+* Provide feedback to improve the fit between [Partner][partners] and [Role][roles], de-energizing when necessary
+* Establish priorities for the [Circle][circles]
 
-The Proponent of a change in the Organizational Structure must be able to present examples of past or present situations where each part of the constructed Proposal would resolve or reduce the Tension. If the Facilitator considers that the Proponent was unable to provide examples and clarification, the Facilitator must discard the Proposal. However, the Facilitator should not judge the accuracy of the arguments presented, but rather if they have been presented with logical reasoning and are therefore plausible.
+**Artifacts**:
+* Energization of [Roles][roles] defined in the [Circle][circles]
 
+The [Guide][guide] holds all non-delegated [Responsibilities][roles] and [Artifacts][roles] of the [Circle][circles].
 
-## **3.6.3 Objections**
+### 4.1.1 Guide Energization
 
-The Facilitator must allow each participant to have the opportunity to raise one or more "Objections" to the submitted Proposal. An Objection is one reason why the Proposal causes harm and moves the Circle backwards. The Facilitator can ask questions to help the "Objector" understand whether what he has brought is a "Valid Objection" or not.
+The [Guide][guide] is chosen by the external [Circle][circles], by any process of [Energization of Defined Roles][energizing-defined-roles] in the external [Circle][circles]. The [Guide][guide] of the widest [Circle][circles] must be determined by the same process that adopted these [Meta-Agreements][meta-agreements].
 
+## 4.2 Representative
 
-## **3.6.4 Validating Objections**
+The "Representative" [Role][roles] has the following initial definition:
 
-An Objection to a Proposed Change in the Organizational Structure is considered valid if the Objector believes that it meets all of the following 4 criteria:
+**Purpose**: _The [Purpose][roles] of the [Circle][circles]_
 
+**Responsibilities**:
+* Seek to understand [Tensions][tensions] brought by [Circle Members][circle-members] and process them when appropriate in the external [Circle][circles]
+* Provide visibility about the [Circle's][circles] health to the external [Circle][circles]
 
+## 4.3 Facilitator
 
-1. Degradation. The Objection is about harm that Proposal could do to the Circle.
-2. Related to Roles. Objection affects one of the Objector's Roles in the Circle.
-3. Causality. This evil is caused by the Proposal, that is, it would not exist without it.
-4. Based on data. The Objection is based on current data or past experience, so it is not an anticipation of future events. However, if the alleged damage is so disastrous that the Circle would not be able to adapt in the future, then this criterion can be disregarded.
+The "Facilitator" [Role][roles] has the following initial definition:
 
-In validating Objections, the Facilitator should not judge the accuracy of the arguments presented, but only if they were presented with logical reasoning and are therefore plausible. Valid objections must be integrated.
+**Purpose**: _Healthy [Circle Meetings][circle-meeting] aligned with the [Meta-Agreements][meta-agreements]_
 
+**Responsibilities**:
+* Facilitate [Circle Meetings][circle-meeting]
 
-## **3.6.5 Integrating Objections**
+## 4.4 Clerk
 
-If there are objections, the facilitator should facilitate a process for integrating them into the proposal, one at a time. The purpose of "Integration" is to modify the Proposal so that it resolves the original Tension, but without causing the objection raised. If the Proposal is changed, the Facilitator should provide another opportunity for participants to raise Objections. If a Proposal is taking a long time to integrate, the Facilitator can discard the Proposal entirely in order to move on to the next item on the List of Tensions.
+The "Clerk" [Role][roles] has the following initial definition:
 
+**Purpose**: _Clear [Meta-Agreements][meta-agreements] and [Organizational Structure][organizational-structure] of the [Circle][circles]_
 
-## **3.6.6 Breach of Meta-Agreements**
+**Responsibilities**:
+* Schedule regular [Circle Meetings][circle-meeting]
+* Record tensions, proposals, objections and outputs during [Circle Meetings][circle-meeting] when requested
+* Interpret [Meta-Agreements][meta-agreements] and [Organizational Structure][organizational-structure] upon request
 
-Any participant may raise an Objection to "Breach of Meta-Agreements" if he or she considers that the Proposal violates one of the rules described in these Meta-Agreements. The Facilitator must then ask the Secretary to interpret whether this is true or not. This special Objection does not need to be validated against the criteria normally used, but it must be integrated like the others.
+**Artifacts**:
+* Records of the [Circle's][circles] [Organizational Structure][organizational-structure]
+* Final interpretation of [Meta-Agreements][meta-agreements] and [Circle][circles] Structure when there is conflict
 
+## 4.5 Essential Elected Roles
 
-## 3.6.7 **Asynchronous Proposals**
+The Essential Roles of [Facilitator][facilitator], [Clerk][clerk] and [Representative][representative] are considered "Essential Elected Roles" and are energized through an election process.
 
-Changes to the Organizational Structure of the Circle may be proposed outside the Circle Meeting and are automatically approved if all Circle Members declare that they have no objection. If any Objection is raised or a participant declares that he / she would like to treat the Tension in a conventional manner, the Proposal should be escalated to Adapt Mode for a conventional Circle Meeting.See the Patterns Library
+### 4.5.1 Eligible Partners
 
+All and only [Circle Members][circle-members] are eligible to energize the [Essential Elected Roles][essential-elected-roles]. However, the [Partner][partners] who energizes the [Guide][guide] [Role][roles] cannot energize the [Role][roles] of [Facilitator][facilitator] or [Representative][representative] in the same [Circle][circles].
 
-# **3.7 Care Mode**
+### 4.5.2 Elections
 
-The "Caring Mode" is a moment of the Circle Meeting whose objective is to stimulate the presence and connection between the participants. This Mode should not be used to make changes to the Organizational Structure of the Circle or to engage Partners in their Roles and Responsibilities.
+Any [Circle Member][circle-members] can request "Elections" for the [Essential Elected Roles][essential-elected-roles]. The Election process is initially done by simple majority to choose a person who will be nominated and then consent is used to effectuate the nomination. The [Organizational Structure][organizational-structure] can define in detail how and under what conditions this process should be facilitated.
 
-View Standards for Care in the Patterns Library
+### 4.5.3 Changes to Essential Roles
 
+The [Essential Roles][essential-roles] of each [Circle][circles] can be changed, as long as the restrictions below are respected:
 
-# **3.8 Prioritizing Meetings**
+* The name and [Purpose][roles] of [Essential Roles][essential-roles] cannot be changed;
+* New [Responsibilities][roles] and [Artifacts][roles] cannot be added to the [Guide][guide] [Role][roles];
+* The initial [Responsibilities][roles] and [Artifacts][roles] of the [Guide][guide] [Role][roles] can be modified or removed completely, as long as they are delegated to another [Role][roles] or process in the [Circle][circles];
+* The initial [Responsibilities][roles] and [Artifacts][roles] of the [Facilitator][facilitator], [Clerk][clerk] and [Representative][representative] [Roles][roles] cannot be removed or modified;
+* [Essential Roles][essential-roles] cannot be removed.
 
-When requested by another Member of a Circle of which you are a member, you must prioritize attending the Circle Meeting rather than working on your Roles.
+#### 4.5.3.1 Changes to Essential Roles don't propagate
 
+Changes made to the [Essential Roles][essential-roles] of a [Circle][circles] apply only to the [Circle][circles] where the modification occurred, that is, they do not propagate to the internal [Circles][circles].
 
+# 5 Energization of Defined Roles
 
-# 4. Essential Roles
+The [Guide][guide] is responsible for inviting [Partners][partners] to energize the [Roles][roles] defined in the [Circle][circles], with the exception of the [Essential Elected Roles][essential-elected-roles]. The [Guide][guide] can invite any [Partner][partners], unless a [Restriction][restrictions] says otherwise. A [Restriction][restrictions] can also modify this process entirely, including removing the corresponding [Responsibility][roles] and [Artifact][roles] from the [Guide][guide].
 
-Each Circle contains "Essential Roles": The  External Link, Internal Link, Facilitator and Secretary.
+## 5.1 Focus
 
+The [Energization][energization] process can also define a "Focus" for the [Partner][partners] who energizes a [Role][roles]. This Focus is an area of activity where the [Purpose][roles], [Responsibilities][roles] and [Artifacts][roles] of the [Role][roles] apply only.
 
-# **4.1 Elected Essential Roles**
+## 5.2 Self-Responsibility
 
-The  Essential Role of Facilitator, Secretary a Lead Link are considered "Essential Elected Roles" and are energized using an election process.
+As a [Partner][partners], you are responsible for addressing the [Tensions][tensions] you perceive, taking actions or engaging other [Partners][partners] in these [Meta-Agreements][meta-agreements]. It is also expected that you ask for help when you don't know which paths to take. This responsibility cannot be transferred to third parties or to a group.
 
-**4.1.1 Eligible Partners**
+## 5.3 Transparency
 
-All and only the Circle Members are eligible to energize the Essential Elected Roles. Even still,  Partners that energize the Role of External Link can't energize the  Roles of Facilitator or Internal Link in the same  Circle.
+As a [Partner][partners], you are expected to share, when requested by other [Partners][partners], all relevant information about the work you do for the [Organization][organization], including your projects, identified actions, prioritization criteria and relevant metrics. When requested, you are also expected to provide estimates and projections about possible completion dates of your work, even if these projections should not be considered deadlines or commitments.
 
+## 5.4 Heroic Act
 
-## **4.1.2 Elections**
+You can temporarily ignore these [Meta-Agreements][meta-agreements] if this is useful and necessary to express the [Organization's][organization] [Purpose][purpose]. Initiatives or requests that have this quality are called "Heroic Acts". You must always seek to repair any damage caused after a Heroic Act, proposing changes in the [Organizational Structure][organizational-structure] or even in these [Meta-Agreements][meta-agreements] if necessary.
 
-Any  Circle Member can solicit  "Elections" for the Essential Elected Roles. The Election process is initially made by a simple majority to choose a person who will be nominated and then consent is used to effect the nomination. Each Circle Member has the right to just one vote. The  Organizational Structure can define in what conditions the process should be facilitated.
-
-
-# **4.2 Altering Essential Roles**
-
-The Essential Roles of each Circle can be changed, as long as the restrictions below are respected:
-
-The name and Purpose of Essential Roles cannot be changed;
-
-New Accountabilities and Artifacts cannot be added to the Role of the External Link;
-
-Initial External Link Role Accountabilities and Artifacts can be modified or removed altogether, as long as they are delegated to another Role or process in the Circle;
-
-The Initial Accountabilities and Artifacts of the Facilitator, Secretary and Internal Link Roles cannot be removed or modified;
-
-Essential Roles cannot be removed.
-
-
-## **4.2.1 Alterations to the Essential Roles don't extend to Internal Circles**
-
-Changes made to the Essential Roles of a Circle apply only to the Circle where the change occurred, that is, they do not extend to the internal Circles.
-
-
-# **4.3 Energizing Defined Roles**
-
-The External Link is responsible for inviting Partners to energize the Roles defined in the Circle, with the exception of Essential Roles. The External Link may invite any Partner, unless a Restriction says otherwise. A Restriction can also modify this process entirely, including removing the Accountability and corresponding Artifact from the External Link.
-
-
-## **4.3.1 Focus**
-
-The Energization process can also define a "Focus" for the Partner  who energizes a Role. The Focus is an area of ​​activity in which the Purpose, Accountabilities and Artifacts of the Role apply only.
-
-**4.4 Energizing the External Link Role**
-
-The External Link is chosen by the External Circle, by the process used for Energizing Roles Defined in the external Circle. The External Link of the external circle must be determined by the same process that adopted these Meta-Agreements.
-
-**4.5 Facilitador**
-
-The role of the "Facilitator" has the following initial definition:
-
-Purpose: Healthy Circle Meetings aligned with Meta-Agreements
-
-Responsibilities:
-
-
-
-*   Facilitate Circle Meetings
-
-**4.6 Secretary**
-
-The role of the "Secretary" has the following initial definition:
-
-Purpose: Clear Meta-Agreements and Organizational Structure of the Circle
-
-Responsibilities:
-
-
-
-*   Schedule regular Circle Meetings
-*   Record requests and proposals made at Circle Meetings
-*   Interpret Meta-Agreements and Organizational Structure upon request
-
-Artifacts:
-
-
-
-*   Records of the Organizational Structure of the Circle
-
-
-# **4.7 External Link**
-
-The role of the "External Link" has the following initial definition:
-
-Purpose: The Purpose of the Circle
-
-Responsibilities:
-
-
-
-*   Structure the Circle to express its Purpose and meet the Accountabilities defined by the external Circle
-*   Invite Partners to energize Roles defined in the Circle
-*   Provide feedback to improve the match between Partner and Role, de-energizing when necessary
-*   Set priorities for the Circle
-
-Artifacts:
-
-
-
-*   Energization of Roles defined in the Circle
-
-The External Link holds all the Circle's non-delegated Accountabilities and Artifacts.
-
-
-# **4.8 Internal Link**
-
-The role of the "Internal Link" has the following initial definition:
-
-Purpose: The Purpose of the Circle
-
-Accountabilities:
-
-
-
-*   Seek to understand Tensions brought on by Circle Members and process them where appropriate in the Outer Circle
-*   Provide visibility on the health of the Circle to the Outer Circle
+<!-- Links -->[meta-agreements]: #meta-agreements-of-the-organic-organization
+[organization]: #1-organization
+[purpose]: #11-purpose
+[partners]: #12-partners
+[tensions]: #13-creative-tensions
+[organizational-structure]: #2-organizational-structure
+[roles]: #21-roles
+[energization]: #211-energization
+[role-authority]: #212-role-authority
+[leaving-roles]: #213-leaving-roles
+[circles]: #22-circles
+[circles-dont-change-definition]: #221-circles-dont-change-their-definition
+[circles-dont-structure-internal]: #222-circles-dont-structure-their-internal-circles
+[circle-artifacts]: #23-circle-artifacts
+[circles-delegate-artifacts]: #231-circles-can-delegate-artifacts
+[circle-members]: #24-circle-members
+[restrictions]: #25-restrictions
+[restrictions-dont-establish]: #251-restrictions-dont-establish-responsibilities
+[circle-priorities]: #26-circle-priorities
+[meetings-and-interactions]: #3-meetings-and-interactions
+[review]: #31-review
+[synchronize]: #32-synchronize
+[adapt]: #33-adapt
+[adapt-operations]: #331-adapt-operations
+[integrative-decision]: #332-integrative-decision
+[proposal]: #3321-proposal
+[presenting-examples]: #3322-presenting-examples
+[facilitator-discard-proposal]: #3323-facilitator-may-discard-the-proposal
+[objections]: #3324-objections
+[valid-objections]: #3325-valid-objections
+[facilitator-discard-objection]: #3326-facilitator-may-discard-the-objection
+[integration]: #3327-integration
+[breaking-meta-agreements]: #3328-breaking-the-meta-agreements
+[care]: #34-care
+[circle-meeting]: #35-circle-meeting
+[only-members-process]: #351-only-members-can-process-tensions
+[meeting-format]: #352-meeting-format
+[absent-members]: #353-absent-members
+[prioritize-meeting]: #354-prioritize-the-meeting
+[facilitation-restrictions]: #36-facilitation-restrictions
+[one-tension]: #361-one-tension-at-a-time
+[tension-list]: #362-tension-list
+[asynchronous-interactions]: #37-asynchronous-interactions
+[new-interactions]: #38-new-interactions
+[essential-roles]: #4-essential-roles
+[guide]: #41-guide
+[guide-energization]: #411-guide-energization
+[representative]: #42-representative
+[facilitator]: #43-facilitator
+[clerk]: #44-clerk
+[essential-elected-roles]: #45-essential-elected-roles
+[eligible-partners]: #451-eligible-partners
+[elections]: #452-elections
+[essential-role-changes]: #453-changes-to-essential-roles
+[changes-dont-propagate]: #4531-changes-to-essential-roles-dont-propagate
+[energizing-defined-roles]: #5-energization-of-defined-roles
+[focus]: #51-focus
+[self-responsibility]: #52-self-responsibility
+[transparency]: #53-transparency
+[heroic-act]: #54-heroic-act
+[meta-agreements]: #meta-agreements-of-the-organic-organization
+[organization]: #1-organization
+[purpose]: #11-purpose
+[partners]: #12-partners
+[tensions]: #13-creative-tensions
+[organizational-structure]: #2-organizational-structure
+[roles]: #21-roles
+[energization]: #211-energization
+[role-authority]: #212-role-authority
+[leaving-roles]: #213-leaving-roles
+[circles]: #22-circles
+[circles-dont-change-definition]: #221-circles-dont-change-their-definition
+[circles-dont-structure-internal]: #222-circles-dont-structure-their-internal-circles
+[circle-artifacts]: #23-circle-artifacts
+[circles-delegate-artifacts]: #231-circles-can-delegate-artifacts
+[circle-members]: #24-circle-members
+[restrictions]: #25-restrictions
+[restrictions-dont-establish]: #251-restrictions-dont-establish-responsibilities
+[circle-priorities]: #26-circle-priorities
+[meetings-and-interactions]: #3-meetings-and-interactions
+[review]: #31-review
+[synchronize]: #32-synchronize
+[adapt]: #33-adapt
+[adapt-operations]: #331-adapt-operations
+[integrative-decision]: #332-integrative-decision
+[proposal]: #3321-proposal
+[presenting-examples]: #3322-presenting-examples
+[facilitator-discard-proposal]: #3323-facilitator-may-discard-the-proposal
+[objections]: #3324-objections
+[valid-objections]: #3325-valid-objections
+[facilitator-discard-objection]: #3326-facilitator-may-discard-the-objection
+[integration]: #3327-integration
+[breaking-meta-agreements]: #3328-breaking-the-meta-agreements
+[care]: #34-care
+[circle-meeting]: #35-circle-meeting
+[only-members-process]: #351-only-members-can-process-tensions
+[meeting-format]: #352-meeting-format
+[absent-members]: #353-absent-members
+[prioritize-meeting]: #354-prioritize-the-meeting
+[facilitation-restrictions]: #36-facilitation-restrictions
+[one-tension]: #361-one-tension-at-a-time
+[tension-list]: #362-tension-list
+[asynchronous-interactions]: #37-asynchronous-interactions
+[new-interactions]: #38-new-interactions
+[essential-roles]: #4-essential-roles
+[guide]: #41-guide
+[guide-energization]: #411-guide-energization
+[representative]: #42-representative
+[facilitator]: #43-facilitator
+[clerk]: #44-clerk
+[essential-elected-roles]: #45-essential-elected-roles
+[eligible-partners]: #451-eligible-partners
+[elections]: #452-elections
+[essential-role-changes]: #453-changes-to-essential-roles
+[changes-dont-propagate]: #4531-changes-to-essential-roles-dont-propagate
+[energizing-defined-roles]: #5-energization-of-defined-roles
+[focus]: #51-focus
+[self-responsibility]: #52-self-responsibility
+[transparency]: #53-transparency
+[heroic-act]: #54-heroic-act


### PR DESCRIPTION
Eu e o Claude colaboramos em uma tradução da última versão dos meta-acordos para inglês

mudanças notáveis:
- substituí o termo "Secretary" por "Clerk", pois me parece se encaixar melhor na semântica do papel (por exemplo, no que diz respeito à autoridade de interpretar papéis). Além disso, "Secretary" pode causar confusão por conta da conotação política "an official in charge of a government department".
- incluí os links para facilitar a navegação

Dei uma revisada geral e parece estar tudo em ordem. Se notar alguma inconsistência durante o uso volto aqui para fazer a correção.

Se aprovado, um próximo passo seria a tradução da biblioteca de padrões e anti-padrões